### PR TITLE
✨ Add metrics for websocket connections to the evaluation server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ benchmark/k6-scripts/test-results/
 
 #Ignore IntelliJ IDEA files
 .idea/
+
+#ignore pyc files in data-analytics-migrator
+/modules/data-analytics-migrator/**/*.pyc
+#ignore wheel files in data-analytics-migrator
+/modules/data-analytics-migrator/**/*.whl
+#ignore dist files in data-analytics-migrator
+/modules/data-analytics-migrator/**/dist

--- a/modules/data-analytics/.gitignore
+++ b/modules/data-analytics/.gitignore
@@ -128,4 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+*.pyc
+
 scheduler.lock

--- a/modules/evaluation-server/src/Api/Setup/ServicesRegister.cs
+++ b/modules/evaluation-server/src/Api/Setup/ServicesRegister.cs
@@ -1,6 +1,8 @@
 using Infrastructure;
 using Serilog;
 using Streaming.DependencyInjection;
+using System.Diagnostics.Metrics;
+using Streaming.Metrics;
 
 namespace Api.Setup;
 
@@ -34,6 +36,9 @@ public static class ServicesRegister
 
         // add bounded memory cache
         services.AddSingleton<BoundedMemoryCache>();
+
+        // add meter factory
+        services.AddSingleton<IStreamingMetrics, StreamingMetrics>();
 
         // streaming services
         services

--- a/modules/evaluation-server/src/Streaming/DependencyInjection/StreamingServiceCollectionExtensions.cs
+++ b/modules/evaluation-server/src/Streaming/DependencyInjection/StreamingServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Npgsql;
 using Streaming.Connections;
 using Streaming.Messages;
 using Streaming.Services;
+using Streaming.Metrics;
 
 namespace Streaming.DependencyInjection;
 
@@ -29,6 +30,9 @@ public static class StreamingServiceCollectionExtensions
 
         // request validator
         services.AddSingleton<IRequestValidator, RequestValidator>();
+
+        // metrics
+        services.AddSingleton<IStreamingMetrics, StreamingMetrics>();
 
         // services
         services

--- a/modules/evaluation-server/src/Streaming/Messages/MessageDispatcher.Log.cs
+++ b/modules/evaluation-server/src/Streaming/Messages/MessageDispatcher.Log.cs
@@ -23,15 +23,24 @@ sealed partial class MessageDispatcher
             ConnectionContext connection
         );
 
-        [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "No handler for message type: {MessageType}",
-            EventName = "NoHandlerFor")]
-        public static partial void NoHandlerFor(
+        [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "Invalid message type",
+            EventName = "InvalidMessageType")]
+        public static partial void InvalidMessageType(
+            ILogger logger,
+            [TagProvider(typeof(ConnectionContextTagProvider), nameof(ConnectionContextTagProvider.RecordTags))]
+            ConnectionContext connection
+        );
+
+        [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Unknown message type: {MessageType}",
+            EventName = "UnknownMessageType")]
+        public static partial void UnknownMessageType(
             ILogger logger,
             string messageType,
             [TagProvider(typeof(ConnectionContextTagProvider), nameof(ConnectionContextTagProvider.RecordTags))]
-            ConnectionContext connection);
+            ConnectionContext connection
+        );
 
-        [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Too many fragments for message",
+        [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "Too many fragments for message",
             EventName = "TooManyFragments")]
         public static partial void TooManyFragments(
             ILogger logger,
@@ -39,16 +48,16 @@ sealed partial class MessageDispatcher
             ConnectionContext connection
         );
 
-        [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "Received invalid message: {Message}",
-            EventName = "ReceivedInvalid")]
-        public static partial void ReceivedInvalid(
+        [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Invalid message format",
+            EventName = "InvalidMessage")]
+        public static partial void InvalidMessage(
             ILogger logger,
-            string message,
             [TagProvider(typeof(ConnectionContextTagProvider), nameof(ConnectionContextTagProvider.RecordTags))]
-            ConnectionContext connection
+            ConnectionContext connection,
+            Exception ex
         );
 
-        [LoggerMessage(EventId = 6, Level = LogLevel.Trace, Message = "Received {Length} bytes message from client",
+        [LoggerMessage(EventId = 7, Level = LogLevel.Trace, Message = "Received {Length} bytes message from client",
             EventName = "Received")]
         public static partial void Received(
             ILogger logger,
@@ -57,7 +66,7 @@ sealed partial class MessageDispatcher
             ConnectionContext connection
         );
 
-        [LoggerMessage(EventId = 7, Level = LogLevel.Warning,
+        [LoggerMessage(EventId = 8, Level = LogLevel.Warning,
             Message = "Received multi-fragment message of length {Length} from client. This should be a rare case.",
             EventName = "ReceivedMultiFragment")]
         public static partial void ReceivedMultiFragment(
@@ -67,18 +76,17 @@ sealed partial class MessageDispatcher
             ConnectionContext connection
         );
 
-        [LoggerMessage(EventId = 8, Level = LogLevel.Error,
-            Message = "Exception occurred while processing message: {Message}",
+        [LoggerMessage(EventId = 9, Level = LogLevel.Error,
+            Message = "Exception occurred while handling message",
             EventName = "ErrorHandleMessage")]
         public static partial void ErrorHandleMessage(
             ILogger logger,
-            string message,
             [TagProvider(typeof(ConnectionContextTagProvider), nameof(ConnectionContextTagProvider.RecordTags))]
             ConnectionContext connection,
             Exception ex
         );
 
-        [LoggerMessage(EventId = 9, Level = LogLevel.Error, Message = "Exception occurred while dispatching message",
+        [LoggerMessage(EventId = 10, Level = LogLevel.Error, Message = "Exception occurred while dispatching message",
             EventName = "ErrorDispatchMessage")]
         public static partial void ErrorDispatchMessage(
             ILogger logger,

--- a/modules/evaluation-server/src/Streaming/Metrics/IStreamingMetrics.cs
+++ b/modules/evaluation-server/src/Streaming/Metrics/IStreamingMetrics.cs
@@ -1,0 +1,10 @@
+namespace Streaming.Metrics;
+
+public interface IStreamingMetrics
+{
+    void ConnectionEstablished(string type);
+    void ConnectionClosed(long durationMs);
+    void ConnectionRejected(string reason);
+    void ConnectionError(string errorType);
+    IDisposable TrackMessageProcessing(string messageType, int messageSizeBytes);
+} 

--- a/modules/evaluation-server/src/Streaming/Metrics/StreamingMetrics.cs
+++ b/modules/evaluation-server/src/Streaming/Metrics/StreamingMetrics.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+
+namespace Streaming.Metrics;
+
+public class StreamingMetrics : IStreamingMetrics
+{
+    private readonly Meter _meter;
+    private readonly ILogger<StreamingMetrics> _logger;
+
+    // Connection instruments
+    private readonly Counter<long> _totalConnections;
+    private readonly UpDownCounter<long> _activeConnections;
+    private readonly Counter<long> _connectionErrors;
+    private readonly Counter<long> _connectionRejections;
+    private readonly Histogram<double> _connectionDuration;
+
+    // Message instruments
+    private readonly Counter<long> _messagesProcessed;
+    private readonly Histogram<long> _messageSize;
+    private readonly Histogram<double> _messageProcessingDuration;
+
+    public StreamingMetrics(ILogger<StreamingMetrics> logger, IMeterFactory meterFactory)
+    {
+        _logger = logger;
+        _meter = meterFactory.Create("FeatBit.Evaluation.Streaming");
+
+        // Connection instruments
+        _totalConnections = _meter.CreateCounter<long>(
+            "websocket.connections.total",
+            description: "Total number of WebSocket connections established"
+        );
+
+        _activeConnections = _meter.CreateUpDownCounter<long>(
+            "websocket.connections.active",
+            description: "Number of currently active WebSocket connections"
+        );
+
+        _connectionErrors = _meter.CreateCounter<long>(
+            "websocket.connections.errors",
+            description: "Total number of WebSocket connection errors"
+        );
+
+        _connectionRejections = _meter.CreateCounter<long>(
+            "websocket.connections.rejections",
+            description: "Total number of rejected WebSocket connections"
+        );
+
+        _connectionDuration = _meter.CreateHistogram<double>(
+            "websocket.connections.duration",
+            unit: "s",
+            description: "Duration of WebSocket connections"
+        );
+
+        // Message instruments
+        _messagesProcessed = _meter.CreateCounter<long>(
+            "websocket.messages.processed",
+            description: "Total number of WebSocket messages processed"
+        );
+
+        _messageSize = _meter.CreateHistogram<long>(
+            "websocket.messages.size",
+            unit: "By",
+            description: "Size of WebSocket messages"
+        );
+
+        _messageProcessingDuration = _meter.CreateHistogram<double>(
+            "websocket.messages.duration",
+            unit: "s",
+            description: "Duration of message processing"
+        );
+
+        _logger.LogInformation("StreamingMetrics initialized with meter name: {MeterName}", _meter.Name);
+    }
+
+    // Connection tracking methods
+    public void ConnectionEstablished(string type)
+    {
+        _logger.LogInformation("Recording connection established of type: {Type}", type);
+        _totalConnections.Add(1, new KeyValuePair<string, object?>("type", type));
+        _activeConnections.Add(1);
+    }
+
+    public void ConnectionClosed(long durationMs)
+    {
+        _logger.LogInformation("Recording connection closed with duration: {DurationMs}ms", durationMs);
+        _activeConnections.Add(-1);
+        _connectionDuration.Record(durationMs / 1000.0);
+    }
+
+    public void ConnectionRejected(string reason)
+    {
+        _logger.LogInformation("Recording connection rejected with reason: {Reason}", reason);
+        _connectionRejections.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    }
+
+    public void ConnectionError(string errorType)
+    {
+        _logger.LogInformation("Recording connection error of type: {ErrorType}", errorType);
+        _connectionErrors.Add(1, new KeyValuePair<string, object?>("error_type", errorType));
+    }
+
+    // Message tracking methods
+    public IDisposable TrackMessageProcessing(string messageType, int messageSizeBytes)
+    {
+        _logger.LogInformation("Recording message processing - Type: {MessageType}, Size: {SizeBytes} bytes", messageType, messageSizeBytes);
+        _messagesProcessed.Add(1, new KeyValuePair<string, object?>("type", messageType));
+        _messageSize.Record(messageSizeBytes, new KeyValuePair<string, object?>("type", messageType));
+        
+        var startTime = DateTime.UtcNow;
+        return new MessageProcessingTimer(this, messageType, startTime, _logger);
+    }
+
+    internal void RecordMessageProcessingDuration(string messageType, DateTime startTime)
+    {
+        var duration = (DateTime.UtcNow - startTime).TotalSeconds;
+        _logger.LogInformation("Recording message processing duration - Type: {MessageType}, Duration: {Duration}s", messageType, duration);
+        _messageProcessingDuration.Record(duration, new KeyValuePair<string, object?>("type", messageType));
+    }
+
+    private class MessageProcessingTimer : IDisposable
+    {
+        private readonly StreamingMetrics _metrics;
+        private readonly string _messageType;
+        private readonly DateTime _startTime;
+        private readonly ILogger _logger;
+
+        public MessageProcessingTimer(StreamingMetrics metrics, string messageType, DateTime startTime, ILogger logger)
+        {
+            _metrics = metrics;
+            _messageType = messageType;
+            _startTime = startTime;
+            _logger = logger;
+        }
+
+        public void Dispose()
+        {
+            _metrics.RecordMessageProcessingDuration(_messageType, _startTime);
+        }
+    }
+} 


### PR DESCRIPTION
This PR adds metrics  for monitoring the websocket connections of the evaluation server. These metrics are needed to determine the capacity and health of the evaluation server. The following meter and metrics are added by this PR.

Meter: FeatBit.Evaluation.Streaming

Metric:
  Name: websocket.connections.total
  Type: Counter
  Description: Total number of WebSocket connections established
  
  Metric:
    Name: websocket.connections.active
    Type: UpDownCounter
    Description: Number of currently active WebSocket connections

  Metric:
    Name: websocket.connections.errors
    Type: Counter
    Description: Total number of WebSocket connection errors
    
  Metric:
    Name: websocket.connections.rejections
    Type: Counter
    Description: Total number of rejected WebSocket connections  

  Metric:
    Name: websocket.connections.duration
    Type: Histogram
    Description: Duration of WebSocket connections

  Metric:
    Name: websocket.messages.processed
    Type: Counter
    Description: Total number of WebSocket messages processed
    
  Metric:
    Name: websocket.messages.size
    Type: Histogram
    Description: Size of WebSocket messages

  Metric:
    Name: websocket.messages.duration
    Type: Histogram
    Description: Duration of message processing"
    
    
Additional logging has been added in response to these events 

Testing:

Configure your application to use OpenTelemetry and add the following environment variable.

` OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES=FeatBit.Evaluation.Streaming`
 
Connect a client to the Evaluation server or configure an run K6 benchmark tests.

Query the metrics in your preferred observability tool (ex. Prometheus, Grafana, etc.)