### PR TITLE
✨ Extend HealthMessage with region/DC/applied watermark

### DIFF
--- a/modules/back-end/src/Domain/Health/HealthMessage.cs
+++ b/modules/back-end/src/Domain/Health/HealthMessage.cs
@@ -1,7 +1,27 @@
-﻿namespace Domain.Health;
+﻿#nullable enable
+
+namespace Domain.Health;
 
 public sealed record HealthMessage
 {
     public required string PodId { get; init; }
     public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// The region the pod is running in. Nullable so heartbeats produced before
+    /// this field existed still deserialize.
+    /// </summary>
+    public string? Region { get; init; }
+
+    /// <summary>
+    /// The data center identifier the pod is running in. Nullable so heartbeats
+    /// produced before this field existed still deserialize.
+    /// </summary>
+    public string? DcId { get; init; }
+
+    /// <summary>
+    /// The highest watermark applied per resource, keyed by resource id. Nullable so
+    /// heartbeats produced before this field existed still deserialize.
+    /// </summary>
+    public Dictionary<Guid, long>? AppliedWatermarks { get; init; }
 }

--- a/modules/back-end/tests/Domain.UnitTests/Health/HealthMessageTests.cs
+++ b/modules/back-end/tests/Domain.UnitTests/Health/HealthMessageTests.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using Domain.Health;
+
+namespace Domain.UnitTests.Health;
+
+public class HealthMessageTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Fact]
+    public void Deserialize_OldFormatJson_WithoutNewFields_Succeeds()
+    {
+        const string json = "{\"podId\":\"p1\",\"timestamp\":\"2026-01-01T00:00:00Z\"}";
+
+        var message = JsonSerializer.Deserialize<HealthMessage>(json, JsonOptions);
+
+        Assert.NotNull(message);
+        Assert.Equal("p1", message!.PodId);
+        Assert.Equal(DateTimeOffset.Parse("2026-01-01T00:00:00Z"), message.Timestamp);
+        Assert.Null(message.Region);
+        Assert.Null(message.DcId);
+        Assert.Null(message.AppliedWatermarks);
+    }
+
+    [Fact]
+    public void Deserialize_NewFormatJson_PopulatesNewFields()
+    {
+        var resourceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var json =
+            "{\"podId\":\"p2\",\"timestamp\":\"2026-01-01T00:00:00Z\"," +
+            "\"region\":\"us-east\",\"dcId\":\"dc-1\"," +
+            $"\"appliedWatermarks\":{{\"{resourceId}\":42}}}}";
+
+        var message = JsonSerializer.Deserialize<HealthMessage>(json, JsonOptions);
+
+        Assert.NotNull(message);
+        Assert.Equal("p2", message!.PodId);
+        Assert.Equal("us-east", message.Region);
+        Assert.Equal("dc-1", message.DcId);
+        Assert.NotNull(message.AppliedWatermarks);
+        Assert.Equal(42, message.AppliedWatermarks![resourceId]);
+    }
+}

--- a/modules/evaluation-server/src/Domain/Health/HealthMessage.cs
+++ b/modules/evaluation-server/src/Domain/Health/HealthMessage.cs
@@ -10,5 +10,23 @@ namespace Domain.Health
     {
         public required string PodId { get; init; }
         public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// The region the pod is running in. Nullable so heartbeats produced before
+        /// this field existed still deserialize.
+        /// </summary>
+        public string? Region { get; init; }
+
+        /// <summary>
+        /// The data center identifier the pod is running in. Nullable so heartbeats
+        /// produced before this field existed still deserialize.
+        /// </summary>
+        public string? DcId { get; init; }
+
+        /// <summary>
+        /// The highest watermark applied per resource, keyed by resource id. Nullable so
+        /// heartbeats produced before this field existed still deserialize.
+        /// </summary>
+        public Dictionary<Guid, long>? AppliedWatermarks { get; init; }
     }
 }


### PR DESCRIPTION
Closes #6

## A5: Extend HealthMessage with region/DC/watermark

Heartbeats must carry enough to populate a lease row (later issue A6).

### Changes
Added three nullable, defaulted fields to the `HealthMessage` record in both Domains (kept in sync):
- `Region` (`string?`)
- `DcId` (`string?`)
- `AppliedWatermarks` (`Dictionary<Guid, long>?`)

Fields are nullable/defaulted so old-format heartbeat JSON (without them) still deserializes.

### Files changed
- `modules/back-end/src/Domain/Health/HealthMessage.cs`
- `modules/evaluation-server/src/Domain/Health/HealthMessage.cs`
- `modules/back-end/tests/Domain.UnitTests/Health/HealthMessageTests.cs` (new)

### Verification
TDD: wrote failing deserialization test first (RED, compile failure on missing fields), then added the fields (GREEN).

`dotnet test --filter FullyQualifiedName~HealthMessage -c Release`:
```
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2 - Domain.UnitTests.dll (net10.0)
```
- Old-format JSON `{"podId":"p1","timestamp":"2026-01-01T00:00:00Z"}` deserializes with new fields null.
- New-format JSON populates Region, DcId, and AppliedWatermarks.

Both Domain projects build with 0 warnings; control-plane Api (consumer of the back-end Domain type) builds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)