### PR TITLE
✨ Add ConsistencyMode config switch (control plane)

### DIFF
--- a/modules/back-end/src/Application/Configuration/ConfigurationExtensions.cs
+++ b/modules/back-end/src/Application/Configuration/ConfigurationExtensions.cs
@@ -2,15 +2,48 @@ using Microsoft.Extensions.Configuration;
 
 namespace Application.Configuration;
 
+/// <summary>
+/// Controls how the control plane propagates changes across data centers.
+/// </summary>
+public enum ConsistencyMode
+{
+    /// <summary>
+    /// Today's behavior: changes are propagated without cross-DC gating (fire-and-forget).
+    /// </summary>
+    BestEffort,
+
+    /// <summary>
+    /// Changes are gated on cross-DC commit before being applied. Opt-in per deployment.
+    /// </summary>
+    GatedCommit
+}
+
 public static class ConfigurationExtensions
 {
     public static bool UseControlPlane(this IConfiguration configuration)
     {
         return configuration.GetValue<bool>("UseControlPlane");
     }
-    
+
     public static string GetRegion(this IConfiguration configuration)
     {
         return configuration.GetValue<string>("Region");
+    }
+
+    /// <summary>
+    /// Reads the control plane consistency mode from configuration key
+    /// "ControlPlane:ConsistencyMode". Returns <see cref="ConsistencyMode.BestEffort"/>
+    /// when the key is unset or cannot be parsed. Never throws.
+    /// </summary>
+    public static ConsistencyMode GetConsistencyMode(this IConfiguration configuration)
+    {
+        var value = configuration.GetValue<string>("ControlPlane:ConsistencyMode");
+
+        if (Enum.TryParse<ConsistencyMode>(value, ignoreCase: true, out var mode))
+        {
+            return mode;
+        }
+
+        return ConsistencyMode.BestEffort;
     }
 }

--- a/modules/control-plane/src/Api/appsettings.json
+++ b/modules/control-plane/src/Api/appsettings.json
@@ -58,6 +58,9 @@
     "ApiKey": ""
   },
   "Region": "local",
+  "ControlPlane": {
+    "ConsistencyMode": "BestEffort"
+  },
   "PodHealth": {
     "TimeoutInSeconds": 90,
     "CheckIntervalInSeconds": 90,

--- a/modules/control-plane/tests/Api.UnitTests/Application/Configuration/ConsistencyModeTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/Configuration/ConsistencyModeTests.cs
@@ -1,0 +1,50 @@
+using Application.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace Api.UnitTests.Application.Configuration;
+
+public class ConsistencyModeTests
+{
+    private static IConfiguration CreateConfiguration(string? consistencyMode)
+    {
+        var data = new Dictionary<string, string?>();
+        if (consistencyMode != null)
+        {
+            data["ControlPlane:ConsistencyMode"] = consistencyMode;
+        }
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(data)
+            .Build();
+    }
+
+    [Fact]
+    public void GetConsistencyMode_WhenUnset_ReturnsBestEffort()
+    {
+        var configuration = CreateConfiguration(null);
+
+        var result = configuration.GetConsistencyMode();
+
+        Assert.Equal(ConsistencyMode.BestEffort, result);
+    }
+
+    [Fact]
+    public void GetConsistencyMode_WhenGatedCommit_ReturnsGatedCommit()
+    {
+        var configuration = CreateConfiguration("GatedCommit");
+
+        var result = configuration.GetConsistencyMode();
+
+        Assert.Equal(ConsistencyMode.GatedCommit, result);
+    }
+
+    [Fact]
+    public void GetConsistencyMode_WhenGarbage_ReturnsBestEffort()
+    {
+        var configuration = CreateConfiguration("not-a-real-mode");
+
+        var result = configuration.GetConsistencyMode();
+
+        Assert.Equal(ConsistencyMode.BestEffort, result);
+    }
+}

--- a/modules/evaluation-server/src/Api/Configuration/ConfigurationExtensions.cs
+++ b/modules/evaluation-server/src/Api/Configuration/ConfigurationExtensions.cs
@@ -1,5 +1,21 @@
 ﻿namespace Api.Configuration;
 
+/// <summary>
+/// Controls how the control plane propagates changes across data centers.
+/// </summary>
+public enum ConsistencyMode
+{
+    /// <summary>
+    /// Today's behavior: changes are propagated without cross-DC gating (fire-and-forget).
+    /// </summary>
+    BestEffort,
+
+    /// <summary>
+    /// Changes are gated on cross-DC commit before being applied. Opt-in per deployment.
+    /// </summary>
+    GatedCommit
+}
+
 public static class ConfigurationExtensions
 {
     public static bool UseControlPlane(this IConfiguration configuration)
@@ -10,5 +26,22 @@ public static class ConfigurationExtensions
     public static int GetHeartbeatIntervalSeconds(this IConfiguration configuration)
     {
         return configuration.GetValue<int>("ControlPlane:HeartbeatIntervalSeconds");
+    }
+
+    /// <summary>
+    /// Reads the control plane consistency mode from configuration key
+    /// "ControlPlane:ConsistencyMode". Returns <see cref="ConsistencyMode.BestEffort"/>
+    /// when the key is unset or cannot be parsed. Never throws.
+    /// </summary>
+    public static ConsistencyMode GetConsistencyMode(this IConfiguration configuration)
+    {
+        var value = configuration.GetValue<string>("ControlPlane:ConsistencyMode");
+
+        if (Enum.TryParse<ConsistencyMode>(value, ignoreCase: true, out var mode))
+        {
+            return mode;
+        }
+
+        return ConsistencyMode.BestEffort;
     }
 }

--- a/modules/evaluation-server/src/Api/appsettings.json
+++ b/modules/evaluation-server/src/Api/appsettings.json
@@ -79,6 +79,7 @@
   "PublicKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvXd47Say6D+c0hYr85jL\n5GF3mjxjZ/Tz2+P/9HDjVsdyXAXs38RmYSR7zFNnlw3iplQXQpEi/NcJoQET+e4K\nmlEILjOujNTJp6VpFYgTsYSncywbFVQielFXozMcco1PJCBPsl8nnGrY6FuIxugT\nxtsr32zILvmqvoB2xE9hRL4uxalY0HI2EInd38PJcmKLBwB8hcIif6Ts5X67mupw\nVwJLYv9xL6GSlenH4fXfx9HpEVeVU8yPbIF8N7pkIC3cHXvKnG0833HouKUi2YgW\n18GR6kn3Co2kmUDeJBABbPCSEzLGJRXeyBa5kVmneOWMv8mWdZRZ5nxIA0WKH/En\nkDXaMYpM8Zyi3OvlS2z93Ow2Ep/Vgm717FkZl3YHEFfcTdKwww428BgHKHzC00vk\nTkdGoexxtzEGuJoOkOYSXjA5yFAH/C5EOFFJyqEjbcAifLr7O3d/TWndBQjEFrFf\nO4syOcd8DRXImYDyARqVLWsaD1JodAxDLeDf4jfTlxhiY6iySgDHpuZeqNAbx4p9\n7pBzL0Nh5DToq4H4t2xN1eYTW+/UPMykaQuQetzecldM/RLWfu6yZM4xmJ7buPDy\n1AqCRZAOiEXSPlVPopmtA2Z6g79k9IbdiDS9skNBPF+v2eJZ58m1xxdTaxen+5pA\nFnnL39/JL0JYG7FOC+VAX0cCAwEAAQ==\n-----END PUBLIC KEY-----",
   "ControlPlane": {
     "Enabled": false,
-    "HeartbeatIntervalSeconds": 60
+    "HeartbeatIntervalSeconds": 60,
+    "ConsistencyMode": "BestEffort"
   }
 }


### PR DESCRIPTION
Closes #2.

Adds the `ConsistencyMode { BestEffort, GatedCommit }` feature gate (default **BestEffort** — no behavior change) plus a `GetConsistencyMode()` config accessor for the control-plane and evaluation-server, so subsequent Option-A gated-commit work can ship inert and be enabled per-deployment.

**Verification:** `dotnet test --filter FullyQualifiedName~ConsistencyMode -c Release` → 3/3 passed; full control-plane suite 39/39 passed; both Api projects build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)