### PR TITLE
✨ Add dc_leases model and ILeaseStore interface

### DIFF
--- a/modules/back-end/src/Application/ControlPlane/ILeaseStore.cs
+++ b/modules/back-end/src/Application/ControlPlane/ILeaseStore.cs
@@ -1,0 +1,32 @@
+using Domain.ControlPlane;
+
+namespace Application.ControlPlane;
+
+/// <summary>
+/// Storage abstraction for data center (DC) membership leases used by the control plane.
+/// Implementations back the live-set / eviction mechanism with a queryable membership record.
+/// </summary>
+public interface ILeaseStore
+{
+    /// <summary>
+    /// Inserts or updates the lease for a data center.
+    /// </summary>
+    /// <param name="lease">The lease to persist.</param>
+    Task UpsertLeaseAsync(DcLease lease);
+
+    /// <summary>
+    /// Returns the current live set of data center leases, that is, all members
+    /// whose <see cref="DcLease.LeaseExpiresAt"/> is greater than <paramref name="now"/>.
+    /// </summary>
+    /// <param name="now">The reference time used to determine which leases are still live.</param>
+    /// <returns>The members with <c>LeaseExpiresAt &gt; now</c>.</returns>
+    Task<IReadOnlyList<DcLease>> GetLiveSetAsync(DateTimeOffset now);
+
+    /// <summary>
+    /// Updates the applied watermark (version) for a specific environment within a data center's lease.
+    /// </summary>
+    /// <param name="dcId">The data center id whose lease should be updated.</param>
+    /// <param name="envId">The environment id whose watermark should be updated.</param>
+    /// <param name="version">The applied version (watermark) to record.</param>
+    Task UpdateAppliedWatermarkAsync(string dcId, Guid envId, long version);
+}

--- a/modules/back-end/src/Domain/ControlPlane/DcLease.cs
+++ b/modules/back-end/src/Domain/ControlPlane/DcLease.cs
@@ -1,0 +1,35 @@
+namespace Domain.ControlPlane;
+
+/// <summary>
+/// Represents a data center (DC) membership lease record used by the control plane
+/// to track which DCs are currently live and what flag/segment versions they have applied.
+/// </summary>
+public class DcLease
+{
+    /// <summary>
+    /// Unique identifier of the data center holding this lease.
+    /// </summary>
+    public string DcId { get; set; }
+
+    /// <summary>
+    /// Region the data center belongs to (for example, a geographic or cloud region).
+    /// </summary>
+    public string Region { get; set; }
+
+    /// <summary>
+    /// Timestamp of the most recent heartbeat received from this data center.
+    /// </summary>
+    public DateTimeOffset LastHeartbeatAt { get; set; }
+
+    /// <summary>
+    /// Timestamp at which this lease expires. A data center is considered live only
+    /// while <see cref="LeaseExpiresAt"/> is in the future.
+    /// </summary>
+    public DateTimeOffset LeaseExpiresAt { get; set; }
+
+    /// <summary>
+    /// The highest applied watermark (version) per environment for this data center,
+    /// keyed by environment id.
+    /// </summary>
+    public Dictionary<Guid, long> AppliedWatermarks { get; set; } = new();
+}

--- a/modules/back-end/tests/Application.UnitTests/ControlPlane/LeaseStoreContractTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/ControlPlane/LeaseStoreContractTests.cs
@@ -1,0 +1,60 @@
+using Application.ControlPlane;
+using Domain.ControlPlane;
+
+namespace Application.UnitTests.ControlPlane;
+
+public class LeaseStoreContractTests
+{
+    private static readonly Guid EnvId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    [Fact]
+    public void DcLease_ExposesExpectedShape()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var lease = new DcLease
+        {
+            DcId = "dc-west",
+            Region = "us-west",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(1),
+            AppliedWatermarks = new Dictionary<Guid, long> { [EnvId] = 42 }
+        };
+
+        Assert.Equal("dc-west", lease.DcId);
+        Assert.Equal("us-west", lease.Region);
+        Assert.Equal(now, lease.LastHeartbeatAt);
+        Assert.Equal(now.AddMinutes(1), lease.LeaseExpiresAt);
+        Assert.Equal(42, lease.AppliedWatermarks[EnvId]);
+    }
+
+    [Fact]
+    public void AppliedWatermarks_DefaultsToEmptyDictionary()
+    {
+        var lease = new DcLease();
+
+        Assert.NotNull(lease.AppliedWatermarks);
+        Assert.Empty(lease.AppliedWatermarks);
+    }
+
+    [Fact]
+    public async Task ILeaseStore_ContractIsCallable()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var live = new DcLease { DcId = "dc-east", LeaseExpiresAt = now.AddMinutes(5) };
+
+        var store = new Mock<ILeaseStore>();
+        store
+            .Setup(x => x.GetLiveSetAsync(It.IsAny<DateTimeOffset>()))
+            .ReturnsAsync(new[] { live });
+
+        await store.Object.UpsertLeaseAsync(live);
+        await store.Object.UpdateAppliedWatermarkAsync("dc-east", EnvId, 7);
+        IReadOnlyList<DcLease> liveSet = await store.Object.GetLiveSetAsync(now);
+
+        Assert.Single(liveSet);
+        Assert.Equal("dc-east", liveSet[0].DcId);
+        store.Verify(x => x.UpsertLeaseAsync(live), Times.Once);
+        store.Verify(x => x.UpdateAppliedWatermarkAsync("dc-east", EnvId, 7), Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #3.

Adds the `DcLease` domain model (`DcId`, `Region`, `LastHeartbeatAt`, `LeaseExpiresAt`, `AppliedWatermarks`) and the `ILeaseStore` interface (`UpsertLeaseAsync`, `GetLiveSetAsync`, `UpdateAppliedWatermarkAsync`) underpinning the Option-A live-set/eviction mechanism. Interface + model only — Mongo (#4) and Postgres (#5) implementations follow.

**Verification:** `dotnet build Backend.sln -c Release` succeeded (0 errors); contract tests 3/3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)