### PR TITLE
🧹 Surface per-instance results from composite Redis broadcast

### DIFF
--- a/modules/control-plane/src/Api/Api.csproj
+++ b/modules/control-plane/src/Api/Api.csproj
@@ -20,5 +20,10 @@
         <ProjectReference Include="..\..\..\back-end\src\Infrastructure\Infrastructure.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- Surface internal members (e.g. CompositeRedisCacheService.BroadcastAsync) to unit tests. -->
+        <InternalsVisibleTo Include="Api.UnitTests"/>
+    </ItemGroup>
+
 
 </Project>

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -13,6 +13,10 @@ public class CompositeRedisCacheService(
     IEnumerable<ICacheService> cacheServices,
     ILogger<CompositeRedisCacheService> logger) : ICacheService
 {
+    // The public ICacheService methods keep returning Task and discard the
+    // per-instance result map so externally observable behavior is unchanged
+    // (swallow-and-continue). The map is surfaced only via the internal
+    // BroadcastAsync for a future commit coordinator.
     public Task UpsertFlagAsync(FeatureFlag flag) =>
         BroadcastAsync(s => s.UpsertFlagAsync(flag), nameof(UpsertFlagAsync));
 
@@ -80,13 +84,34 @@ public class CompositeRedisCacheService(
     public Task DeleteConnectionMadeAsync(ConnectionMessage connectionMessage) =>
         BroadcastAsync(s => s.DeleteConnectionMadeAsync(connectionMessage), nameof(DeleteConnectionMadeAsync));
 
-    private Task BroadcastAsync(Func<ICacheService, Task> action, string operationName)
+    /// <summary>
+    /// Broadcasts <paramref name="action"/> to every cache instance, swallowing and
+    /// logging per-instance failures so one DC's outage does not fail the others.
+    /// Returns a per-instance success map so callers (e.g. a future commit coordinator)
+    /// can observe partial failure instead of having it silently swallowed.
+    /// </summary>
+    // TODO: key by DC id once instances carry identity (C2/C3).
+    internal async Task<IReadOnlyDictionary<string, bool>> BroadcastAsync(
+        Func<ICacheService, Task> action,
+        string operationName)
     {
-        var tasks = cacheServices.Select(s => ExecuteSafelyAsync(s, action, operationName));
-        return Task.WhenAll(tasks);
+        var instances = cacheServices.ToList();
+        var tasks = instances
+            .Select(s => ExecuteSafelyAsync(s, action, operationName))
+            .ToList();
+
+        var outcomes = await Task.WhenAll(tasks);
+
+        var results = new Dictionary<string, bool>(outcomes.Length);
+        for (var i = 0; i < outcomes.Length; i++)
+        {
+            results[i.ToString()] = outcomes[i];
+        }
+
+        return results;
     }
 
-    private async Task ExecuteSafelyAsync(
+    private async Task<bool> ExecuteSafelyAsync(
         ICacheService service,
         Func<ICacheService, Task> action,
         string operationName)
@@ -94,6 +119,7 @@ public class CompositeRedisCacheService(
         try
         {
             await action(service);
+            return true;
         }
         catch (OperationCanceledException)
         {
@@ -106,6 +132,7 @@ public class CompositeRedisCacheService(
                 "Redis cache broadcast operation '{Operation}' failed for implementation {CacheService}. Continuing.",
                 operationName,
                 service.GetType().FullName);
+            return false;
         }
     }
 

--- a/modules/control-plane/tests/Api.UnitTests/Application/Caches/CompositeRedisCacheServiceTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/Caches/CompositeRedisCacheServiceTests.cs
@@ -76,4 +76,36 @@ public class CompositeRedisCacheServiceTests
         _local.Verify(s => s.DeletePodConnection(podId), Times.Once);
         _remote.Verify(s => s.DeletePodConnection(podId), Times.Once);
     }
+
+    [Fact]
+    public async Task BroadcastAsync_WhenAllInstancesSucceed_ReturnsTrueForEachIndex()
+    {
+        var sut = CreateSut();
+
+        var result = await sut.BroadcastAsync(_ => Task.CompletedTask, "Op");
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result["0"]);
+        Assert.True(result["1"]);
+    }
+
+    [Fact]
+    public async Task BroadcastAsync_WhenOneInstanceThrows_ReturnsFalseForThatIndexAndTrueForOthers()
+    {
+        // _remote is index 1 and is configured to fail for this operation.
+        var failing = new Mock<ICacheService>();
+        failing.Setup(s => s.DeletePodConnection(It.IsAny<Guid>()))
+               .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var sut = new CompositeRedisCacheService(
+            new[] { _local.Object, failing.Object }, _logger.Object);
+
+        // Should not throw out of the broadcast.
+        var result = await sut.BroadcastAsync(
+            s => s.DeletePodConnection(Guid.NewGuid()), nameof(ICacheService.DeletePodConnection));
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result["0"]);
+        Assert.False(result["1"]);
+    }
 }


### PR DESCRIPTION
Closes #13.

`CompositeRedisCacheService.BroadcastAsync` now returns `IReadOnlyDictionary<string,bool>` (keyed by ordinal index for now; TODO to key by DC id in #14/#15) and `ExecuteSafelyAsync` returns a success bool. Public `ICacheService` methods are unchanged — they still return `Task` and still swallow-and-continue per instance, so behavior is identical. This exposes partial-failure info for the future commit coordinator.

Made testable via `internal` + `InternalsVisibleTo(Api.UnitTests)`.

**Verification:** `dotnet test --filter FullyQualifiedName~CompositeRedisCacheService -c Release` → 6/6 passed; full control-plane suite 38/38 passed; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)