### PR TITLE
✨ Add Redis stage/commit storage for flags

### DIFF
--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
@@ -25,6 +25,35 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
         await Redis.SortedSetAddAsync(index.Key, index.Member, index.Score);
     }
 
+    /// <summary>
+    /// Stages a new flag version (B1 stage/commit storage). Writes ONLY the versioned value key
+    /// <c>featbit:flag:{id}:v{ts}</c>; it does NOT move the committed pointer and does NOT touch
+    /// the env flag sorted-set index. The previously committed value therefore stays readable
+    /// until <see cref="CommitFlagAsync"/> is called.
+    /// </summary>
+    public async Task StageFlagAsync(FeatureFlag flag, long ts)
+    {
+        var staged = RedisCaches.FlagStaged(flag, ts);
+        await Redis.StringSetAsync(staged.Key, staged.Value);
+    }
+
+    /// <summary>
+    /// Commits a previously staged flag version (B1 stage/commit storage). Sets the committed
+    /// pointer <c>featbit:flag-committed:{id}</c> to <paramref name="ts"/> AND advances the env
+    /// flag sorted-set index score to <paramref name="ts"/> (mirroring <see cref="UpsertFlagAsync"/>'s
+    /// index logic), making the staged version the authoritative committed value.
+    /// </summary>
+    public async Task CommitFlagAsync(Guid envId, string flagId, long ts)
+    {
+        // flip the committed pointer to the staged version
+        var pointerKey = RedisCaches.FlagCommittedPointer(Guid.Parse(flagId));
+        await Redis.StringSetAsync(pointerKey, ts);
+
+        // advance the env flag index score (mirror UpsertFlag index logic)
+        var indexKey = RedisKeys.FlagIndex(envId);
+        await Redis.SortedSetAddAsync(indexKey, flagId, ts);
+    }
+
     public async Task DeleteFlagAsync(Guid envId, Guid flagId)
     {
         // delete cache

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisCaches.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisCaches.cs
@@ -28,6 +28,41 @@ public static class RedisCaches
         return index;
     }
 
+    // --- B1 stage/commit storage -------------------------------------------------------------
+    // To keep the old committed flag value readable while a new version is staged, a staged value
+    // is written under a versioned key derived from the existing flag value key (RedisKeys.Flag):
+    //   featbit:flag:{id}:v{ts}        -- immutable per-version snapshot ("staged" value)
+    // A separate committed-pointer key records which version is currently authoritative:
+    //   featbit:flag-committed:{id}    -- value is the committed timestamp ({ts}) as a string
+    // Staging writes only the versioned key; committing flips the pointer (and the env index).
+    // Both keys reuse the existing FlagPrefix convention so they share key-space ownership with
+    // the legacy single-value key produced by RedisKeys.Flag / RedisCaches.Flag.
+
+    /// <summary>
+    /// The versioned, immutable value key for a single staged flag version: <c>featbit:flag:{id}:v{ts}</c>.
+    /// </summary>
+    public static RedisKey FlagVersion(Guid id, long ts) => new($"{RedisKeys.Flag(id)}:v{ts}");
+
+    /// <summary>
+    /// The committed-pointer key holding the timestamp of the currently committed flag version:
+    /// <c>featbit:flag-committed:{id}</c>.
+    /// </summary>
+    public static RedisKey FlagCommittedPointer(Guid id) => new($"{FlagCommittedPrefix}{id}");
+
+    /// <summary>
+    /// Builds the versioned staged value entry for <paramref name="flag"/> scored by
+    /// <paramref name="ts"/>. Mirrors <see cref="Flag(FeatureFlag)"/> serialization.
+    /// </summary>
+    public static KeyValuePair<RedisKey, RedisValue> FlagStaged(FeatureFlag flag, long ts)
+    {
+        var key = FlagVersion(flag.Id, ts);
+        var value = JsonSerializer.SerializeToUtf8Bytes(flag, ReusableJsonSerializerOptions.Web);
+
+        return new KeyValuePair<RedisKey, RedisValue>(key, value);
+    }
+
+    private const string FlagCommittedPrefix = "featbit:flag-committed:";
+
     public static KeyValuePair<RedisKey, RedisValue> Segment(Segment segment)
     {
         var key = RedisKeys.Segment(segment.Id);

--- a/modules/back-end/tests/Application.UnitTests/Caches/RedisStageCommitTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/Caches/RedisStageCommitTests.cs
@@ -1,0 +1,145 @@
+using Domain.FeatureFlags;
+using Infrastructure.Caches.Redis;
+using StackExchange.Redis;
+
+namespace Application.UnitTests.Caches;
+
+/// <summary>
+/// Integration tests for the B1 Redis stage/commit storage feature.
+///
+/// These tests require a real Redis instance. The orchestrating issue (#8) spins one up on a
+/// NON-default port (6380) because 6379 is taken by another project:
+///   docker run -d --rm -p 6380:6379 --name b1-redis redis:7-alpine
+///
+/// The connection string can be overridden via the B1_REDIS env var. xunit 2.x has no runtime
+/// Assert.Skip, so if Redis is unreachable the tests fail loudly with a clear message rather
+/// than passing silently — the orchestrating issue requires verification against a real Redis.
+/// </summary>
+public class RedisStageCommitTests : IAsyncLifetime
+{
+    private const string DefaultConnection = "localhost:6380";
+
+    private ConnectionMultiplexer? _mux;
+    private RedisCacheService? _sut;
+
+    private static string ConnectionString =>
+        Environment.GetEnvironmentVariable("B1_REDIS") ?? DefaultConnection;
+
+    public async Task InitializeAsync()
+    {
+        var options = ConfigurationOptions.Parse(ConnectionString);
+        options.AbortOnConnectFail = false;
+        options.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(options);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{ConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6380:6379 --name b1-redis redis:7-alpine " +
+                "(or set the B1_REDIS env var).");
+        }
+
+        _sut = new RedisCacheService(new TestRedisClient(_mux));
+    }
+
+    public Task DisposeAsync()
+    {
+        _mux?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task StageThenCommit_KeepsOldCommittedValueReadableUntilCommit()
+    {
+
+        var sut = _sut!;
+        var db = _mux!.GetDatabase();
+
+        var envId = Guid.NewGuid();
+        var flagId = Guid.NewGuid();
+        var flagIdString = flagId.ToString();
+
+        // baseline: commit v1 first so there is an existing committed pointer
+        var v1 = 1_000L;
+        var flagV1 = NewFlag(envId, flagId, v1);
+        await sut.StageFlagAsync(flagV1, v1);
+        await sut.CommitFlagAsync(envId, flagIdString, v1);
+
+        var committedKey = RedisCaches.FlagCommittedPointer(flagId);
+        var indexKey = RedisKeys.FlagIndex(envId);
+
+        Assert.Equal(v1.ToString(), (string?)await db.StringGetAsync(committedKey));
+        Assert.Equal(v1, await db.SortedSetScoreAsync(indexKey, flagIdString));
+
+        // stage v2: the versioned value key must be written, but the committed
+        // pointer and the index score must remain pointing at v1.
+        var v2 = 2_000L;
+        var flagV2 = NewFlag(envId, flagId, v2);
+        await sut.StageFlagAsync(flagV2, v2);
+
+        Assert.True(await db.KeyExistsAsync(RedisCaches.FlagVersion(flagId, v2)),
+            "staged versioned value key should exist");
+        Assert.True(await db.KeyExistsAsync(RedisCaches.FlagVersion(flagId, v1)),
+            "previously committed versioned value key should still exist");
+
+        // ACCEPTANCE: after StageFlagAsync the committed pointer is unchanged.
+        Assert.Equal(v1.ToString(), (string?)await db.StringGetAsync(committedKey));
+        Assert.Equal(v1, await db.SortedSetScoreAsync(indexKey, flagIdString));
+
+        // commit v2: pointer flips to v2 and index score advances to v2.
+        await sut.CommitFlagAsync(envId, flagIdString, v2);
+
+        // ACCEPTANCE: after CommitFlagAsync, pointer == ts.
+        Assert.Equal(v2.ToString(), (string?)await db.StringGetAsync(committedKey));
+        Assert.Equal(v2, await db.SortedSetScoreAsync(indexKey, flagIdString));
+
+        // cleanup
+        await db.KeyDeleteAsync(committedKey);
+        await db.KeyDeleteAsync(RedisCaches.FlagVersion(flagId, v1));
+        await db.KeyDeleteAsync(RedisCaches.FlagVersion(flagId, v2));
+        await db.SortedSetRemoveAsync(indexKey, flagIdString);
+    }
+
+    [Fact]
+    public async Task StageFlagAsync_DoesNotTouchSortedSetIndex()
+    {
+
+        var sut = _sut!;
+        var db = _mux!.GetDatabase();
+
+        var envId = Guid.NewGuid();
+        var flagId = Guid.NewGuid();
+        var flagIdString = flagId.ToString();
+        var indexKey = RedisKeys.FlagIndex(envId);
+
+        var ts = 5_000L;
+        var flag = NewFlag(envId, flagId, ts);
+
+        // No prior commit, so the index has no member for this flag.
+        await sut.StageFlagAsync(flag, ts);
+
+        // staging must NOT add the flag to the env index nor move the committed pointer.
+        Assert.False((await db.SortedSetScoreAsync(indexKey, flagIdString)).HasValue,
+            "staging must not write the sorted-set index");
+        Assert.False(await db.KeyExistsAsync(RedisCaches.FlagCommittedPointer(flagId)),
+            "staging must not write the committed pointer");
+
+        // cleanup
+        await db.KeyDeleteAsync(RedisCaches.FlagVersion(flagId, ts));
+    }
+
+    private static FeatureFlag NewFlag(Guid envId, Guid flagId, long ts) => new()
+    {
+        Id = flagId,
+        EnvId = envId,
+        UpdatedAt = DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime
+    };
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase();
+    }
+}


### PR DESCRIPTION
Closes #8.

Keeps the old committed flag value readable while a new version is staged. Adds versioned value keys `featbit:flag:{id}:v{ts}` plus a committed-pointer key `featbit:flag-committed:{id}`; `StageFlagAsync` writes only the versioned value (no pointer/index move), `CommitFlagAsync` advances the pointer and the env sorted-set index. `ICacheService` interface untouched; existing `UpsertFlagAsync` unchanged.

**Verification (real Redis on :6380):** 2 new integration tests pass; existing Application.UnitTests 16/16; back-end build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)