### PR TITLE
✨ Implement Mongo ILeaseStore (dc_leases)

### DIFF
--- a/modules/back-end/src/Infrastructure/Persistence/DbServiceCollectionExtensions.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/DbServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ public static class DbServiceCollectionExtensions
             services.AddTransient<IWebhookService, MongoServices.WebhookService>();
             services.AddTransient<IInsightService, MongoServices.InsightService>();
             services.AddTransient<IRefreshTokenService, MongoServices.RefreshTokenService>();
+            services.AddTransient<Application.ControlPlane.ILeaseStore, MongoServices.MongoLeaseStore>();
         }
 
         void AddEntityFrameworkCoreServices()

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/MongoLeaseStore.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/MongoLeaseStore.cs
@@ -1,0 +1,63 @@
+using Application.ControlPlane;
+using Domain.ControlPlane;
+using Infrastructure.Persistence.MongoDb;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Options;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver;
+
+namespace Infrastructure.Services.MongoDb;
+
+public class MongoLeaseStore : ILeaseStore
+{
+    public const string CollectionName = "dc_leases";
+
+    private readonly IMongoCollection<DcLease> _collection;
+
+    static MongoLeaseStore()
+    {
+        // The applied-watermark map is keyed by Guid. By default the driver serializes a
+        // dictionary with non-string keys as an array of key/value pairs, which prevents
+        // dotted-path $set updates like "appliedWatermarks.{envId}". Force the Document
+        // representation so each environment id becomes a field name we can target directly.
+        if (!BsonClassMap.IsClassMapRegistered(typeof(DcLease)))
+        {
+            BsonClassMap.RegisterClassMap<DcLease>(map =>
+            {
+                map.AutoMap();
+                map.MapMember(x => x.AppliedWatermarks)
+                    .SetSerializer(
+                        new DictionaryInterfaceImplementerSerializer<Dictionary<Guid, long>>(
+                            DictionaryRepresentation.Document,
+                            new GuidSerializer(BsonType.String),
+                            new Int64Serializer()));
+            });
+        }
+    }
+
+    public MongoLeaseStore(MongoDbClient mongoDb)
+    {
+        _collection = mongoDb.Database.GetCollection<DcLease>(CollectionName);
+    }
+
+    public async Task UpsertLeaseAsync(DcLease lease)
+    {
+        var filter = Builders<DcLease>.Filter.Eq(x => x.DcId, lease.DcId);
+        await _collection.ReplaceOneAsync(filter, lease, new ReplaceOptions { IsUpsert = true });
+    }
+
+    public async Task<IReadOnlyList<DcLease>> GetLiveSetAsync(DateTimeOffset now)
+    {
+        var filter = Builders<DcLease>.Filter.Gt(x => x.LeaseExpiresAt, now);
+        var leases = await _collection.Find(filter).ToListAsync();
+        return leases;
+    }
+
+    public async Task UpdateAppliedWatermarkAsync(string dcId, Guid envId, long version)
+    {
+        var filter = Builders<DcLease>.Filter.Eq(x => x.DcId, dcId);
+        var update = Builders<DcLease>.Update.Set($"appliedWatermarks.{envId}", version);
+        await _collection.UpdateOneAsync(filter, update);
+    }
+}

--- a/modules/back-end/tests/Application.IntegrationTests/ControlPlane/MongoLeaseStoreTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/ControlPlane/MongoLeaseStoreTests.cs
@@ -5,7 +5,7 @@ using Infrastructure.Services.MongoDb;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
-namespace Application.UnitTests.ControlPlane;
+namespace Application.IntegrationTests.ControlPlane;
 
 /// <summary>
 /// Integration tests for <see cref="MongoLeaseStore"/> that run against a real MongoDB instance.

--- a/modules/back-end/tests/Application.UnitTests/ControlPlane/MongoLeaseStoreTests.cs
+++ b/modules/back-end/tests/Application.UnitTests/ControlPlane/MongoLeaseStoreTests.cs
@@ -1,0 +1,134 @@
+using Application.ControlPlane;
+using Domain.ControlPlane;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace Application.UnitTests.ControlPlane;
+
+/// <summary>
+/// Integration tests for <see cref="MongoLeaseStore"/> that run against a real MongoDB instance.
+/// Each run uses a throwaway database that is dropped on disposal so shared state is never polluted.
+/// </summary>
+public class MongoLeaseStoreTests : IAsyncLifetime
+{
+    private const string ConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
+
+    private static readonly Guid EnvId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private readonly string _databaseName = $"featbit_a3_test_{Guid.NewGuid():N}";
+    private MongoClient _client = null!;
+    private MongoLeaseStore _sut = null!;
+
+    public Task InitializeAsync()
+    {
+        _client = new MongoClient(ConnectionString);
+
+        var options = Options.Create(new MongoDbOptions
+        {
+            ConnectionString = ConnectionString,
+            Database = _databaseName
+        });
+
+        var mongoDb = new MongoDbClient(options);
+        _sut = new MongoLeaseStore(mongoDb);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _client.DropDatabaseAsync(_databaseName);
+    }
+
+    [Fact]
+    public async Task UpsertLeaseAsync_IsIdempotentOnDcId()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var first = new DcLease
+        {
+            DcId = "dc-west",
+            Region = "us-west",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(5)
+        };
+        await _sut.UpsertLeaseAsync(first);
+
+        // upsert again with the same DcId but a refreshed expiry -> must replace, not duplicate
+        var second = new DcLease
+        {
+            DcId = "dc-west",
+            Region = "us-west-2",
+            LastHeartbeatAt = now.AddSeconds(30),
+            LeaseExpiresAt = now.AddMinutes(10)
+        };
+        await _sut.UpsertLeaseAsync(second);
+
+        var live = await _sut.GetLiveSetAsync(now);
+
+        Assert.Single(live);
+        Assert.Equal("dc-west", live[0].DcId);
+        Assert.Equal("us-west-2", live[0].Region);
+        Assert.Equal(second.LeaseExpiresAt.ToUnixTimeMilliseconds(), live[0].LeaseExpiresAt.ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public async Task GetLiveSetAsync_ExcludesExpiredLeases()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var liveLease = new DcLease
+        {
+            DcId = "dc-east",
+            Region = "us-east",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(5)
+        };
+        var expiredLease = new DcLease
+        {
+            DcId = "dc-stale",
+            Region = "us-stale",
+            LastHeartbeatAt = now.AddMinutes(-10),
+            LeaseExpiresAt = now.AddMinutes(-5)
+        };
+
+        await _sut.UpsertLeaseAsync(liveLease);
+        await _sut.UpsertLeaseAsync(expiredLease);
+
+        var live = await _sut.GetLiveSetAsync(now);
+
+        Assert.Single(live);
+        Assert.Equal("dc-east", live[0].DcId);
+    }
+
+    [Fact]
+    public async Task UpdateAppliedWatermarkAsync_PersistsWatermark()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var lease = new DcLease
+        {
+            DcId = "dc-watermark",
+            Region = "us-west",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(5)
+        };
+        await _sut.UpsertLeaseAsync(lease);
+
+        await _sut.UpdateAppliedWatermarkAsync("dc-watermark", EnvId, 99);
+
+        var live = await _sut.GetLiveSetAsync(now);
+        var stored = Assert.Single(live);
+
+        Assert.True(stored.AppliedWatermarks.ContainsKey(EnvId));
+        Assert.Equal(99, stored.AppliedWatermarks[EnvId]);
+
+        // updating again overwrites the prior value
+        await _sut.UpdateAppliedWatermarkAsync("dc-watermark", EnvId, 123);
+
+        var reloaded = (await _sut.GetLiveSetAsync(now)).Single();
+        Assert.Equal(123, reloaded.AppliedWatermarks[EnvId]);
+    }
+}


### PR DESCRIPTION
Closes #4.

Mongo implementation of the Wave-1 `ILeaseStore` on collection `dc_leases`: upsert by `DcId` (idempotent), `GetLiveSetAsync(now)` = members with `LeaseExpiresAt > now`, `UpdateAppliedWatermarkAsync` = dotted `$set` on `appliedWatermarks.{envId}`. Registered under the MongoDB provider branch in `DbServiceCollectionExtensions`. A guarded `BsonClassMap` forces `Dictionary<Guid,long>` to a document representation so per-env dotted updates work.

**Verification (real Mongo):** 3 new integration tests pass (idempotent upsert, expired-lease exclusion, watermark persistence); existing contract tests green; back-end build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)