### PR TITLE
✨ Implement Postgres ILeaseStore (dc_leases) + schema

### DIFF
--- a/infra/postgresql/docker-entrypoint-initdb.d/v5.5.0.sql
+++ b/infra/postgresql/docker-entrypoint-initdb.d/v5.5.0.sql
@@ -1,0 +1,16 @@
+\connect featbit
+
+-- Control plane data center membership leases (Option A consistency).
+-- One row per data center, keyed by dc_id. Mirrors the Mongo "dc_leases" collection.
+CREATE TABLE IF NOT EXISTS dc_leases
+(
+    dc_id              text PRIMARY KEY,
+    region             text,
+    last_heartbeat_at  timestamptz,
+    lease_expires_at   timestamptz,
+    applied_watermarks jsonb
+);
+
+-- The live-set query filters on lease_expires_at > now().
+CREATE INDEX IF NOT EXISTS ix_dc_leases_lease_expires_at
+    ON dc_leases (lease_expires_at);

--- a/modules/back-end/src/Infrastructure/Persistence/DbServiceCollectionExtensions.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/DbServiceCollectionExtensions.cs
@@ -98,6 +98,7 @@ public static class DbServiceCollectionExtensions
             services.AddTransient<IWebhookService, EntityFrameworkCoreServices.WebhookService>();
             services.AddTransient<IInsightService, EntityFrameworkCoreServices.InsightService>();
             services.AddTransient<IRefreshTokenService, EntityFrameworkCoreServices.RefreshTokenService>();
+            services.AddTransient<Application.ControlPlane.ILeaseStore, EntityFrameworkCoreServices.PostgresLeaseStore>();
         }
     }
 }

--- a/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/AppDbContext.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/AppDbContext.cs
@@ -41,5 +41,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration(new WebhookConfiguration());
         modelBuilder.ApplyConfiguration(new WebhookDeliveryConfiguration());
         modelBuilder.ApplyConfiguration(new QueueMessageConfiguration());
+
+        modelBuilder.ApplyConfiguration(new DcLeaseConfiguration());
     }
 }

--- a/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/DcLeaseConfiguration.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/DcLeaseConfiguration.cs
@@ -1,0 +1,26 @@
+using Domain.ControlPlane;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.EntityFrameworkCore.Configurations;
+
+public class DcLeaseConfiguration : IEntityTypeConfiguration<DcLease>
+{
+    public void Configure(EntityTypeBuilder<DcLease> builder)
+    {
+        builder.ToTable("dc_leases");
+
+        // DcId is the natural key for a data center membership lease (one row per DC).
+        builder.HasKey(x => x.DcId);
+        builder.Property(x => x.DcId).IsRequired();
+
+        builder.Property(x => x.Region);
+        builder.Property(x => x.LastHeartbeatAt);
+        builder.Property(x => x.LeaseExpiresAt);
+
+        // The per-environment applied watermark map is stored as jsonb, mirroring how other
+        // complex/dictionary properties (e.g. EndUser.CustomizedProperties) are mapped. Npgsql's
+        // dynamic-json support serializes the Dictionary<Guid, long> to/from the jsonb column.
+        builder.Property(x => x.AppliedWatermarks).HasColumnType("jsonb");
+    }
+}

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/PostgresLeaseStore.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/PostgresLeaseStore.cs
@@ -1,0 +1,70 @@
+using Application.ControlPlane;
+using Domain.ControlPlane;
+using Infrastructure.Persistence.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Services.EntityFrameworkCore;
+
+/// <summary>
+/// Entity Framework Core / Postgres implementation of <see cref="ILeaseStore"/>.
+/// Backs the control-plane live-set and watermark tracking with the <c>dc_leases</c> table.
+/// </summary>
+public class PostgresLeaseStore(AppDbContext dbContext) : ILeaseStore
+{
+    private DbSet<DcLease> Leases => dbContext.Set<DcLease>();
+
+    public async Task UpsertLeaseAsync(DcLease lease)
+    {
+        // Upsert keyed by DcId so repeated heartbeats for the same data center replace the
+        // existing row instead of inserting duplicates. The query is run with tracking so the
+        // change tracker can issue an UPDATE (or INSERT) regardless of the context default.
+        var existing = await Leases
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.DcId == lease.DcId);
+
+        if (existing == null)
+        {
+            await Leases.AddAsync(lease);
+        }
+        else
+        {
+            existing.Region = lease.Region;
+            existing.LastHeartbeatAt = lease.LastHeartbeatAt;
+            existing.LeaseExpiresAt = lease.LeaseExpiresAt;
+            existing.AppliedWatermarks = lease.AppliedWatermarks;
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    public async Task<IReadOnlyList<DcLease>> GetLiveSetAsync(DateTimeOffset now)
+    {
+        var leases = await Leases
+            .Where(x => x.LeaseExpiresAt > now)
+            .ToListAsync();
+
+        return leases;
+    }
+
+    public async Task UpdateAppliedWatermarkAsync(string dcId, Guid envId, long version)
+    {
+        var lease = await Leases
+            .AsTracking()
+            .FirstOrDefaultAsync(x => x.DcId == dcId);
+
+        if (lease == null)
+        {
+            return;
+        }
+
+        // Reassign the dictionary so EF detects the jsonb column as modified even when the
+        // context is configured for change tracking on a reference-typed property.
+        var watermarks = new Dictionary<Guid, long>(lease.AppliedWatermarks)
+        {
+            [envId] = version
+        };
+        lease.AppliedWatermarks = watermarks;
+
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/modules/back-end/tests/Application.IntegrationTests/ControlPlane/PostgresLeaseStoreTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/ControlPlane/PostgresLeaseStoreTests.cs
@@ -1,0 +1,148 @@
+using Domain.ControlPlane;
+using Domain.Utils;
+using Infrastructure.Persistence.EntityFrameworkCore;
+using Infrastructure.Services.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Application.IntegrationTests.ControlPlane;
+
+/// <summary>
+/// Integration tests for <see cref="PostgresLeaseStore"/> that run against a real Postgres instance.
+/// The throwaway database (port 5433 in CI/local verification) is materialized via the EF model
+/// (EnsureCreated) and the <c>dc_leases</c> table is truncated between tests so state never leaks.
+/// The Npgsql data source mirrors production (snake_case naming + dynamic json for the jsonb map).
+/// </summary>
+public class PostgresLeaseStoreTests : IAsyncLifetime
+{
+    private const string ConnectionString =
+        "Host=localhost;Port=5433;Database=featbit;Username=postgres;Password=please_change_me";
+
+    private static readonly Guid EnvId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private NpgsqlDataSource _dataSource = null!;
+    private AppDbContext _dbContext = null!;
+    private PostgresLeaseStore _sut = null!;
+
+    public async Task InitializeAsync()
+    {
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString);
+        dataSourceBuilder
+            .EnableDynamicJson()
+            .ConfigureJsonOptions(ReusableJsonSerializerOptions.Web);
+        _dataSource = dataSourceBuilder.Build();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(_dataSource)
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        _dbContext = new AppDbContext(options);
+
+        // Materialize the EF model (including the DcLease configuration) into the throwaway db.
+        await _dbContext.Database.EnsureCreatedAsync();
+
+        // Start from a clean dc_leases table for every test in this class.
+        await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM dc_leases");
+
+        _sut = new PostgresLeaseStore(_dbContext);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _dataSource.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task UpsertLeaseAsync_IsIdempotentOnDcId()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var first = new DcLease
+        {
+            DcId = "dc-west",
+            Region = "us-west",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(5)
+        };
+        await _sut.UpsertLeaseAsync(first);
+
+        // upsert again with the same DcId but a refreshed expiry -> must replace, not duplicate
+        var second = new DcLease
+        {
+            DcId = "dc-west",
+            Region = "us-west-2",
+            LastHeartbeatAt = now.AddSeconds(30),
+            LeaseExpiresAt = now.AddMinutes(10)
+        };
+        await _sut.UpsertLeaseAsync(second);
+
+        var live = await _sut.GetLiveSetAsync(now);
+
+        Assert.Single(live);
+        Assert.Equal("dc-west", live[0].DcId);
+        Assert.Equal("us-west-2", live[0].Region);
+        Assert.Equal(
+            second.LeaseExpiresAt.ToUnixTimeMilliseconds(),
+            live[0].LeaseExpiresAt.ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public async Task GetLiveSetAsync_ExcludesExpiredLeases()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var liveLease = new DcLease
+        {
+            DcId = "dc-east",
+            Region = "us-east",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(5)
+        };
+        var expiredLease = new DcLease
+        {
+            DcId = "dc-stale",
+            Region = "us-stale",
+            LastHeartbeatAt = now.AddMinutes(-10),
+            LeaseExpiresAt = now.AddMinutes(-5)
+        };
+
+        await _sut.UpsertLeaseAsync(liveLease);
+        await _sut.UpsertLeaseAsync(expiredLease);
+
+        var live = await _sut.GetLiveSetAsync(now);
+
+        Assert.Single(live);
+        Assert.Equal("dc-east", live[0].DcId);
+    }
+
+    [Fact]
+    public async Task UpdateAppliedWatermarkAsync_PersistsWatermark()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        var lease = new DcLease
+        {
+            DcId = "dc-watermark",
+            Region = "us-west",
+            LastHeartbeatAt = now,
+            LeaseExpiresAt = now.AddMinutes(5)
+        };
+        await _sut.UpsertLeaseAsync(lease);
+
+        await _sut.UpdateAppliedWatermarkAsync("dc-watermark", EnvId, 99);
+
+        var live = await _sut.GetLiveSetAsync(now);
+        var stored = Assert.Single(live);
+
+        Assert.True(stored.AppliedWatermarks.ContainsKey(EnvId));
+        Assert.Equal(99, stored.AppliedWatermarks[EnvId]);
+
+        // updating again overwrites the prior value
+        await _sut.UpdateAppliedWatermarkAsync("dc-watermark", EnvId, 123);
+
+        var reloaded = (await _sut.GetLiveSetAsync(now)).Single();
+        Assert.Equal(123, reloaded.AppliedWatermarks[EnvId]);
+    }
+}


### PR DESCRIPTION
Closes #5.

Postgres/EF counterpart to the merged `MongoLeaseStore` (#4): `PostgresLeaseStore` over `AppDbContext`, `DcLeaseConfiguration` (`applied_watermarks` as jsonb, snake_case), `ApplyConfiguration` in `AppDbContext`, registration under the EF/Postgres provider branch in `DbServiceCollectionExtensions`, and a new `infra/postgresql/.../v5.5.0.sql` creating the `dc_leases` table.

**Verification (real Postgres on :5433, EnsureCreated from the EF model):** 3/3 integration tests pass (idempotent upsert, expired-lease exclusion, watermark persistence) — placed in **Application.IntegrationTests**. Full back-end build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)