### PR TITLE
🧹 Relocate Redis stage/commit tests to Application.IntegrationTests

### DIFF
--- a/modules/back-end/tests/Application.IntegrationTests/Caches/RedisStageCommitTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Caches/RedisStageCommitTests.cs
@@ -2,7 +2,7 @@ using Domain.FeatureFlags;
 using Infrastructure.Caches.Redis;
 using StackExchange.Redis;
 
-namespace Application.UnitTests.Caches;
+namespace Application.IntegrationTests.Caches;
 
 /// <summary>
 /// Integration tests for the B1 Redis stage/commit storage feature.


### PR DESCRIPTION
Follow-up fix. The B1 test relocation pushed to #30 didn't land — #30 was merged at its pre-relocation head (`2edb65dd`), so `RedisStageCommitTests` (which needs a live Redis) is still in `Application.UnitTests`. The Mongo equivalents (#31/#32) relocated correctly.

This moves it to `Application.IntegrationTests/Caches/` so the unit suite stays infra-free.

**Verification:** both test projects build; the moved test passes 2/2 against Redis on :6380.