### PR TITLE
✨ Heartbeat handler upserts a DC lease (GatedCommit)

### DIFF
--- a/modules/control-plane/src/Api/Application/ControlPlane/HeartbeatMessageHandler.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/HeartbeatMessageHandler.cs
@@ -1,5 +1,8 @@
 ﻿using System.Text.Json;
 using Application.Caches;
+using Application.Configuration;
+using Application.ControlPlane;
+using Domain.ControlPlane;
 using Domain.Health;
 using Domain.Messages;
 
@@ -7,8 +10,12 @@ namespace Api.Application.ControlPlane;
 
 public class HeartbeatMessageHandler(
     [FromKeyedServices("compositeCache")] ICacheService cacheService,
-    ILogger<HeartbeatMessageHandler> logger) : IMessageHandler
+    ILogger<HeartbeatMessageHandler> logger,
+    ILeaseStore leaseStore,
+    IConfiguration configuration) : IMessageHandler
 {
+    private const int DefaultLeaseTtlSeconds = 15;
+
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public string Topic => ControlPlaneTopics.PodHeartbeat;
@@ -27,11 +34,36 @@ public class HeartbeatMessageHandler(
             }
 
             await cacheService.UpsertPodHeartbeat(heartBeatMessage!);
+
+            // Under GatedCommit, the heartbeat doubles as live-set membership: persist a
+            // DC lease so the control plane can track which DCs are currently live and what
+            // versions they have applied. BestEffort keeps today's fire-and-forget behavior.
+            if (configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit)
+            {
+                await UpsertLeaseAsync(heartBeatMessage!);
+            }
         }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to process heartbeat message: {Message}", message);
         }
+    }
+
+    private async Task UpsertLeaseAsync(HealthMessage heartBeatMessage)
+    {
+        var leaseTtlSeconds = configuration.GetValue("ControlPlane:LeaseTtlSeconds", DefaultLeaseTtlSeconds);
+        var leaseTtl = TimeSpan.FromSeconds(leaseTtlSeconds);
+
+        var lease = new DcLease
+        {
+            DcId = heartBeatMessage.DcId ?? heartBeatMessage.PodId,
+            Region = heartBeatMessage.Region ?? string.Empty,
+            LastHeartbeatAt = heartBeatMessage.Timestamp,
+            LeaseExpiresAt = heartBeatMessage.Timestamp + leaseTtl,
+            AppliedWatermarks = heartBeatMessage.AppliedWatermarks ?? new Dictionary<Guid, long>()
+        };
+
+        await leaseStore.UpsertLeaseAsync(lease);
     }
 
     private bool TryValidate(HealthMessage? heartBeatMessage, string rawMessage)

--- a/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/HeartbeatMessageHandlerTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/HeartbeatMessageHandlerTests.cs
@@ -1,7 +1,10 @@
 using System.Text.Json;
 using Api.Application.ControlPlane;
 using Application.Caches;
+using Application.ControlPlane;
+using Domain.ControlPlane;
 using Domain.Health;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -11,9 +14,26 @@ public class HeartbeatMessageHandlerTests
 {
     private readonly Mock<ICacheService> _cache = new();
     private readonly Mock<ILogger<HeartbeatMessageHandler>> _logger = new();
+    private readonly Mock<ILeaseStore> _leaseStore = new();
 
-    private HeartbeatMessageHandler CreateSut()
-        => new(_cache.Object, _logger.Object);
+    private HeartbeatMessageHandler CreateSut(IConfiguration? configuration = null)
+        => new(_cache.Object, _logger.Object, _leaseStore.Object, configuration ?? BuildConfig());
+
+    private static IConfiguration BuildConfig(
+        string? consistencyMode = null, string? leaseTtlSeconds = null)
+    {
+        var values = new Dictionary<string, string?>();
+        if (consistencyMode is not null)
+        {
+            values["ControlPlane:ConsistencyMode"] = consistencyMode;
+        }
+        if (leaseTtlSeconds is not null)
+        {
+            values["ControlPlane:LeaseTtlSeconds"] = leaseTtlSeconds;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
 
     [Fact]
     public async Task HandleAsync_WhenValid_CallsUpsertPodHeartbeat()
@@ -96,5 +116,139 @@ public class HeartbeatMessageHandlerTests
 
         _cache.Verify(x => x.UpsertPodHeartbeat(It.Is<HealthMessage>(m =>
             m.PodId == podId && m.Timestamp == timestamp)), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenBestEffort_DoesNotUpsertLease()
+    {
+        // BestEffort is the default; no lease should be written.
+        var sut = CreateSut();
+        var payload = JsonSerializer.Serialize(new HealthMessage
+        {
+            PodId = Guid.NewGuid().ToString(),
+            Timestamp = DateTimeOffset.UtcNow
+        });
+
+        await sut.HandleAsync(payload);
+
+        _cache.Verify(x => x.UpsertPodHeartbeat(It.IsAny<HealthMessage>()), Times.Once);
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.IsAny<DcLease>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenBestEffortExplicit_DoesNotUpsertLease()
+    {
+        var sut = CreateSut(BuildConfig(consistencyMode: "BestEffort"));
+        var payload = JsonSerializer.Serialize(new HealthMessage
+        {
+            PodId = Guid.NewGuid().ToString(),
+            Timestamp = DateTimeOffset.UtcNow
+        });
+
+        await sut.HandleAsync(payload);
+
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.IsAny<DcLease>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGatedCommit_UpsertsLeaseWithDefaultTtl()
+    {
+        var sut = CreateSut(BuildConfig(consistencyMode: "GatedCommit"));
+        var timestamp = DateTimeOffset.UtcNow;
+        var watermarks = new Dictionary<Guid, long> { [Guid.NewGuid()] = 42 };
+        var msg = new HealthMessage
+        {
+            PodId = Guid.NewGuid().ToString(),
+            Timestamp = timestamp,
+            Region = "west",
+            DcId = "dc-1",
+            AppliedWatermarks = watermarks
+        };
+        var payload = JsonSerializer.Serialize(msg);
+
+        await sut.HandleAsync(payload);
+
+        _cache.Verify(x => x.UpsertPodHeartbeat(It.IsAny<HealthMessage>()), Times.Once);
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.Is<DcLease>(l =>
+            l.DcId == "dc-1" &&
+            l.Region == "west" &&
+            l.LastHeartbeatAt == timestamp &&
+            l.LeaseExpiresAt == timestamp.AddSeconds(15) &&
+            l.AppliedWatermarks.Count == 1)), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGatedCommitWithCustomTtl_UsesConfiguredTtl()
+    {
+        var sut = CreateSut(BuildConfig(consistencyMode: "GatedCommit", leaseTtlSeconds: "30"));
+        var timestamp = DateTimeOffset.UtcNow;
+        var msg = new HealthMessage
+        {
+            PodId = Guid.NewGuid().ToString(),
+            Timestamp = timestamp,
+            Region = "east",
+            DcId = "dc-2"
+        };
+        var payload = JsonSerializer.Serialize(msg);
+
+        await sut.HandleAsync(payload);
+
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.Is<DcLease>(l =>
+            l.DcId == "dc-2" &&
+            l.LeaseExpiresAt == timestamp.AddSeconds(30))), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGatedCommitAndDcIdNull_FallsBackToPodId()
+    {
+        var sut = CreateSut(BuildConfig(consistencyMode: "GatedCommit"));
+        var podId = Guid.NewGuid().ToString();
+        var msg = new HealthMessage
+        {
+            PodId = podId,
+            Timestamp = DateTimeOffset.UtcNow,
+            Region = "west"
+            // DcId omitted (null)
+        };
+        var payload = JsonSerializer.Serialize(msg);
+
+        await sut.HandleAsync(payload);
+
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.Is<DcLease>(l =>
+            l.DcId == podId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGatedCommitAndWatermarksNull_UsesEmptyDictionary()
+    {
+        var sut = CreateSut(BuildConfig(consistencyMode: "GatedCommit"));
+        var msg = new HealthMessage
+        {
+            PodId = Guid.NewGuid().ToString(),
+            Timestamp = DateTimeOffset.UtcNow,
+            DcId = "dc-3"
+            // AppliedWatermarks omitted (null)
+        };
+        var payload = JsonSerializer.Serialize(msg);
+
+        await sut.HandleAsync(payload);
+
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.Is<DcLease>(l =>
+            l.AppliedWatermarks != null && l.AppliedWatermarks.Count == 0)), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGatedCommitButInvalidMessage_DoesNotUpsertLease()
+    {
+        var sut = CreateSut(BuildConfig(consistencyMode: "GatedCommit"));
+        var payload = JsonSerializer.Serialize(new HealthMessage
+        {
+            PodId = "",
+            Timestamp = DateTimeOffset.UtcNow
+        });
+
+        await sut.HandleAsync(payload);
+
+        _leaseStore.Verify(x => x.UpsertLeaseAsync(It.IsAny<DcLease>()), Times.Never);
     }
 }


### PR DESCRIPTION
Closes #7.

Turns existing pod heartbeats into live-set membership. Under **GatedCommit** only, after `UpsertPodHeartbeat` the handler upserts a `DcLease` (DcId fallback to PodId, Region/AppliedWatermarks from the `HealthMessage`, `LeaseExpiresAt = Timestamp + ControlPlane:LeaseTtlSeconds`, default 15s). **BestEffort path unchanged.** `ILeaseStore` already has Mongo+Postgres registrations, so the new dependency resolves.

**Verification (unit, mocked ILeaseStore — no infra):** Heartbeat filter 17/17; full control-plane suite 48/48; GatedCommit upserts with correct expiry, BestEffort writes no lease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)