### PR TITLE
✨ Add staged-flag version GC worker (GatedCommit)

### DIFF
--- a/modules/back-end/src/Infrastructure/AppService/StagedFlagGcWorker.cs
+++ b/modules/back-end/src/Infrastructure/AppService/StagedFlagGcWorker.cs
@@ -1,0 +1,200 @@
+using System.Globalization;
+using Application.Configuration;
+using Infrastructure.Caches.Redis;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Infrastructure.AppService;
+
+/// <summary>
+/// Garbage-collects superseded, immutable versioned flag value keys written by the B1 stage/commit
+/// storage (<c>featbit:flag:{id}:v{ts}</c>).
+///
+/// Periodically scans the versioned key-space via Redis <c>SCAN</c> (never <c>KEYS</c>), groups keys
+/// by flag id, reads each flag's committed pointer (<c>featbit:flag-committed:{id}</c>), and deletes
+/// only versions whose <c>ts</c> is strictly LESS THAN the committed <c>ts</c>. The currently
+/// committed version, and any newer (staged-future) version with <c>ts &gt;= committed</c>, is never
+/// deleted. A flag with no committed pointer is skipped entirely so unstaged/uncommitted versions
+/// are left untouched.
+///
+/// The worker only runs under <see cref="ConsistencyMode.GatedCommit"/>; otherwise it no-ops.
+/// </summary>
+public sealed class StagedFlagGcWorker : BackgroundService
+{
+    /// <summary>
+    /// Default interval between GC sweeps when not overridden via
+    /// <c>ControlPlane:StagedFlagGc:IntervalSeconds</c>.
+    /// </summary>
+    public static readonly TimeSpan DefaultInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>SCAN match pattern selecting only versioned flag value keys.</summary>
+    private const string VersionedFlagKeyPattern = "featbit:flag:*:v*";
+
+    private const string VersionSeparator = ":v";
+
+    private readonly IRedisClient _redis;
+    private readonly bool _enabled;
+    private readonly TimeSpan _interval;
+    private readonly ILogger<StagedFlagGcWorker> _logger;
+
+    public StagedFlagGcWorker(
+        IRedisClient redis,
+        IConfiguration configuration,
+        ILogger<StagedFlagGcWorker> logger)
+    {
+        _redis = redis;
+        _logger = logger;
+        _enabled = configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit;
+
+        var seconds = configuration.GetValue<int?>("ControlPlane:StagedFlagGc:IntervalSeconds");
+        _interval = seconds is > 0
+            ? TimeSpan.FromSeconds(seconds.Value)
+            : DefaultInterval;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_enabled)
+        {
+            _logger.LogInformation(
+                "Staged flag GC worker disabled (consistency mode is not GatedCommit).");
+            return;
+        }
+
+        using var timer = new PeriodicTimer(_interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                var deleted = await RunGcOnceAsync(stoppingToken);
+                if (deleted > 0)
+                {
+                    _logger.LogInformation(
+                        "Staged flag GC swept {DeletedCount} superseded versioned flag key(s).",
+                        deleted);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // ignore cancellation from the timer loop itself
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while sweeping staged flag versions.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs a single GC sweep over all versioned flag value keys and returns the number of keys
+    /// deleted. Exposed so it can be invoked directly (e.g. by integration tests) without waiting on
+    /// the periodic timer.
+    ///
+    /// For each flag: if it has no committed pointer the flag is skipped; otherwise every versioned
+    /// key with <c>ts &lt; committed</c> is deleted. The committed version and any version with
+    /// <c>ts &gt;= committed</c> are preserved.
+    /// </summary>
+    public async Task<int> RunGcOnceAsync(CancellationToken cancellationToken = default)
+    {
+        var db = _redis.GetDatabase();
+
+        // Group versioned keys by flag id: id -> list of (key, ts).
+        var byFlag = new Dictionary<Guid, List<(RedisKey Key, long Ts)>>();
+
+        foreach (var endPoint in _redis.Connection.GetEndPoints())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var server = _redis.Connection.GetServer(endPoint);
+            if (server.IsReplica)
+            {
+                continue;
+            }
+
+            await foreach (var key in server.KeysAsync(pattern: VersionedFlagKeyPattern, pageSize: 250)
+                               .WithCancellation(cancellationToken))
+            {
+                if (!TryParseVersionedKey(key, out var flagId, out var ts))
+                {
+                    continue;
+                }
+
+                if (!byFlag.TryGetValue(flagId, out var versions))
+                {
+                    versions = new List<(RedisKey, long)>();
+                    byFlag[flagId] = versions;
+                }
+
+                versions.Add((key, ts));
+            }
+        }
+
+        var toDelete = new List<RedisKey>();
+
+        foreach (var (flagId, versions) in byFlag)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var pointerKey = RedisCaches.FlagCommittedPointer(flagId);
+            var pointerValue = await db.StringGetAsync(pointerKey);
+
+            // No committed pointer => never delete (unstaged/uncommitted versions are untouched).
+            if (pointerValue.IsNullOrEmpty ||
+                !long.TryParse((string?)pointerValue, NumberStyles.Integer, CultureInfo.InvariantCulture,
+                    out var committedTs))
+            {
+                continue;
+            }
+
+            // Delete only versions strictly older than the committed version.
+            foreach (var (key, ts) in versions)
+            {
+                if (ts < committedTs)
+                {
+                    toDelete.Add(key);
+                }
+            }
+        }
+
+        if (toDelete.Count == 0)
+        {
+            return 0;
+        }
+
+        await db.KeyDeleteAsync(toDelete.ToArray());
+        return toDelete.Count;
+    }
+
+    /// <summary>
+    /// Parses a versioned flag value key of the form <c>featbit:flag:{guid}:v{ts}</c>. The committed
+    /// pointer key (<c>featbit:flag-committed:{id}</c>) and the bare value key
+    /// (<c>featbit:flag:{id}</c>) do not match this shape and are rejected.
+    /// </summary>
+    private static bool TryParseVersionedKey(RedisKey key, out Guid flagId, out long ts)
+    {
+        flagId = default;
+        ts = default;
+
+        var s = key.ToString();
+        const string prefix = "featbit:flag:";
+        if (!s.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // remainder is "{guid}:v{ts}"
+        var separatorIndex = s.LastIndexOf(VersionSeparator, StringComparison.Ordinal);
+        if (separatorIndex <= prefix.Length)
+        {
+            return false;
+        }
+
+        var idPart = s.Substring(prefix.Length, separatorIndex - prefix.Length);
+        var tsPart = s[(separatorIndex + VersionSeparator.Length)..];
+
+        return Guid.TryParse(idPart, out flagId) &&
+               long.TryParse(tsPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out ts);
+    }
+}

--- a/modules/back-end/src/Infrastructure/ConfigureServices.cs
+++ b/modules/back-end/src/Infrastructure/ConfigureServices.cs
@@ -29,6 +29,10 @@ public static class ConfigureServices
         // flag schedule worker
         services.AddHostedService<AppServices.FlagScheduleWorker>();
 
+        // staged flag version GC worker (B5): reclaims superseded versioned flag value keys.
+        // The worker itself no-ops unless ControlPlane:ConsistencyMode is GatedCommit.
+        services.AddHostedService<AppServices.StagedFlagGcWorker>();
+
         // track usage
         services.AddOptions<UsageTrackingOptions>()
             .Bind(configuration.GetSection(UsageTrackingOptions.UsageTracking))

--- a/modules/back-end/tests/Application.IntegrationTests/AppService/StagedFlagGcWorkerTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/AppService/StagedFlagGcWorkerTests.cs
@@ -1,0 +1,148 @@
+using Application.Configuration;
+using Infrastructure.AppService;
+using Infrastructure.Caches.Redis;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+
+namespace Application.IntegrationTests.AppService;
+
+/// <summary>
+/// Integration tests for the B5 staged-flag version GC worker (<see cref="StagedFlagGcWorker"/>).
+///
+/// These tests require a real Redis instance. The orchestrating issue (#12) spins one up on a
+/// NON-default port (6382) because 6379/6380/6381 are taken by other projects:
+///   docker run -d --rm -p 6382:6379 --name b5-redis redis:7-alpine
+///
+/// The connection string can be overridden via the B5_REDIS env var. xunit 2.x has no runtime
+/// Assert.Skip, so if Redis is unreachable the tests fail loudly with a clear message rather
+/// than passing silently — the orchestrating issue requires verification against a real Redis.
+/// </summary>
+public class StagedFlagGcWorkerTests : IAsyncLifetime
+{
+    private const string DefaultConnection = "localhost:6382";
+
+    private ConnectionMultiplexer? _mux;
+
+    private static string ConnectionString =>
+        Environment.GetEnvironmentVariable("B5_REDIS") ?? DefaultConnection;
+
+    public async Task InitializeAsync()
+    {
+        var options = ConfigurationOptions.Parse(ConnectionString);
+        options.AbortOnConnectFail = false;
+        options.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(options);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{ConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6382:6379 --name b5-redis redis:7-alpine " +
+                "(or set the B5_REDIS env var).");
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _mux?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task RunGcOnce_DeletesSupersededVersions_KeepsCommittedAndPointer()
+    {
+        var db = _mux!.GetDatabase();
+        var sut = CreateSut();
+
+        var flagId = Guid.NewGuid();
+        const long v1 = 1000L;
+        const long v2 = 2000L;
+
+        var v1Key = RedisCaches.FlagVersion(flagId, v1);
+        var v2Key = RedisCaches.FlagVersion(flagId, v2);
+        var pointerKey = RedisCaches.FlagCommittedPointer(flagId);
+
+        // seed: two versioned value keys + a committed pointer at v2.
+        await db.StringSetAsync(v1Key, "v1-value");
+        await db.StringSetAsync(v2Key, "v2-value");
+        await db.StringSetAsync(pointerKey, v2);
+
+        try
+        {
+            var deleted = await sut.RunGcOnceAsync();
+
+            Assert.True(deleted >= 1, "at least the superseded :v1 key should be deleted");
+
+            // ACCEPTANCE: superseded version is gone.
+            Assert.False(await db.KeyExistsAsync(v1Key), "superseded :v1000 key must be deleted");
+
+            // ACCEPTANCE: committed version + pointer are intact.
+            Assert.True(await db.KeyExistsAsync(v2Key), "committed :v2000 key must be kept");
+            Assert.Equal(v2.ToString(), (string?)await db.StringGetAsync(pointerKey));
+        }
+        finally
+        {
+            await db.KeyDeleteAsync(v1Key);
+            await db.KeyDeleteAsync(v2Key);
+            await db.KeyDeleteAsync(pointerKey);
+        }
+    }
+
+    [Fact]
+    public async Task RunGcOnce_LeavesFlagWithoutCommittedPointerUntouched()
+    {
+        var db = _mux!.GetDatabase();
+        var sut = CreateSut();
+
+        var flagId = Guid.NewGuid();
+        const long v1 = 1000L;
+        const long v2 = 2000L;
+
+        var v1Key = RedisCaches.FlagVersion(flagId, v1);
+        var v2Key = RedisCaches.FlagVersion(flagId, v2);
+        var pointerKey = RedisCaches.FlagCommittedPointer(flagId);
+
+        // seed: versioned value keys but NO committed pointer.
+        await db.StringSetAsync(v1Key, "v1-value");
+        await db.StringSetAsync(v2Key, "v2-value");
+
+        try
+        {
+            await sut.RunGcOnceAsync();
+
+            // ACCEPTANCE: no committed pointer => nothing is deleted.
+            Assert.True(await db.KeyExistsAsync(v1Key), ":v1000 must be kept (no committed pointer)");
+            Assert.True(await db.KeyExistsAsync(v2Key), ":v2000 must be kept (no committed pointer)");
+            Assert.False(await db.KeyExistsAsync(pointerKey));
+        }
+        finally
+        {
+            await db.KeyDeleteAsync(v1Key);
+            await db.KeyDeleteAsync(v2Key);
+        }
+    }
+
+    private StagedFlagGcWorker CreateSut()
+    {
+        // GatedCommit so the worker is enabled; RunGcOnceAsync runs the sweep regardless of timer.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ControlPlane:ConsistencyMode"] = nameof(ConsistencyMode.GatedCommit)
+            })
+            .Build();
+
+        return new StagedFlagGcWorker(
+            new TestRedisClient(_mux!),
+            configuration,
+            NullLogger<StagedFlagGcWorker>.Instance);
+    }
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase();
+    }
+}


### PR DESCRIPTION
Closes #12.

Reclaims superseded versioned flag value keys from B1. `StagedFlagGcWorker` (a `BackgroundService`, default 5-min interval via `ControlPlane:StagedFlagGc:IntervalSeconds`) uses Redis `SCAN` (not `KEYS`) over `featbit:flag:*:v*`, groups by flag id, reads `RedisCaches.FlagCommittedPointer(id)`, and deletes only versions with `ts < committed` — the committed and any `>= committed` (staged-future) version are preserved; flags without a committed pointer are skipped. Runs only under **GatedCommit**. Does not modify `RedisCaches`/`RedisCacheService` (read-only use of the public key builders).

**Verification (real Redis :6382):** 2 integration tests pass (deletes `:v1000`, keeps committed `:v2000` + pointer; no-pointer flag untouched); back-end build clean. Test in **Application.IntegrationTests**; sweep exposed as `RunGcOnceAsync` for direct testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)