### PR TITLE
✨ Stage-only flag change handling under GatedCommit

### DIFF
--- a/modules/back-end/src/Application/Caches/ICacheService.cs
+++ b/modules/back-end/src/Application/Caches/ICacheService.cs
@@ -11,6 +11,19 @@ public interface ICacheService
 {
     Task UpsertFlagAsync(FeatureFlag flag);
 
+    /// <summary>
+    /// Stages a new flag version (B1 stage/commit storage) without moving the committed
+    /// pointer or touching the env flag index, so the previously committed value stays
+    /// readable until <see cref="CommitFlagAsync"/> is called.
+    /// </summary>
+    Task StageFlagAsync(FeatureFlag flag, long ts);
+
+    /// <summary>
+    /// Commits a previously staged flag version (B1 stage/commit storage): moves the
+    /// committed pointer and advances the env flag index to <paramref name="ts"/>.
+    /// </summary>
+    Task CommitFlagAsync(Guid envId, string flagId, long ts);
+
     Task DeleteFlagAsync(Guid envId, Guid flagId);
 
     Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment);

--- a/modules/back-end/src/Infrastructure/Caches/None/NoneCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/None/NoneCacheService.cs
@@ -12,6 +12,10 @@ public class NoneCacheService : ICacheService
 {
     public Task UpsertFlagAsync(FeatureFlag flag) => Task.CompletedTask;
 
+    public Task StageFlagAsync(FeatureFlag flag, long ts) => Task.CompletedTask;
+
+    public Task CommitFlagAsync(Guid envId, string flagId, long ts) => Task.CompletedTask;
+
     public Task DeleteFlagAsync(Guid envId, Guid flagId) => Task.CompletedTask;
 
     public Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment) => Task.CompletedTask;

--- a/modules/control-plane/src/Api/Application/ControlPlane/FeatureFlagChangeMessageHandler.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/FeatureFlagChangeMessageHandler.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Application.Caches;
 using Application.Configuration;
 using Application.FeatureFlags;
+using Application.Services;
 using Domain.FeatureFlags;
 using Domain.Messages;
 using Domain.Utils;
@@ -11,6 +12,7 @@ namespace Api.Application.ControlPlane;
 public class FeatureFlagChangeMessageHandler(
     [FromKeyedServices("compositeCache")] ICacheService cacheService,
     IMessageProducer messageProducer,
+    IFeatureFlagService featureFlagService,
     ILogger<FeatureFlagChangeMessageHandler> logger,
     IConfiguration configuration) : IMessageHandler
 {
@@ -37,8 +39,23 @@ public class FeatureFlagChangeMessageHandler(
                     notification.Deserialize<OnFeatureFlagChanged>(ReusableJsonSerializerOptions.Web);
                 if (deserializedFlagNotification != null)
                 {
-                    await cacheService.UpsertFlagAsync(deserializedFlagNotification.Flag);
-                    await messageProducer.PublishAsync(Topics.FeatureFlagChange, deserializedFlagNotification.Flag);
+                    var flag = deserializedFlagNotification.Flag;
+
+                    if (configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit)
+                    {
+                        // GatedCommit (C2): stage the new value to every DC's Redis and record the
+                        // Mongo pending change, but do NOT publish to the evaluation-server topic yet.
+                        // The commit/publish is C3's responsibility.
+                        var ts = new DateTimeOffset(flag.UpdatedAt).ToUnixTimeMilliseconds();
+                        await cacheService.StageFlagAsync(flag, ts);
+                        await featureFlagService.SetPendingAsync(flag.EnvId, flag.Key, flag, ts);
+                    }
+                    else
+                    {
+                        // BestEffort: unchanged fire-and-forget propagation.
+                        await cacheService.UpsertFlagAsync(flag);
+                        await messageProducer.PublishAsync(Topics.FeatureFlagChange, flag);
+                    }
                 }
 
                 var webHooksMessage = new

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -20,6 +20,12 @@ public class CompositeRedisCacheService(
     public Task UpsertFlagAsync(FeatureFlag flag) =>
         BroadcastAsync(s => s.UpsertFlagAsync(flag), nameof(UpsertFlagAsync));
 
+    public Task StageFlagAsync(FeatureFlag flag, long ts) =>
+        BroadcastAsync(s => s.StageFlagAsync(flag, ts), nameof(StageFlagAsync));
+
+    public Task CommitFlagAsync(Guid envId, string flagId, long ts) =>
+        BroadcastAsync(s => s.CommitFlagAsync(envId, flagId, ts), nameof(CommitFlagAsync));
+
     public Task DeleteFlagAsync(Guid envId, Guid flagId) =>
         BroadcastAsync(s => s.DeleteFlagAsync(envId, flagId), nameof(DeleteFlagAsync));
 

--- a/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/FeatureFlagChangeMessageHandlerTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/FeatureFlagChangeMessageHandlerTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Api.Application.ControlPlane;
 using Application.Caches;
 using Application.FeatureFlags;
+using Application.Services;
 using Domain.AuditLogs;
 using Domain.FeatureFlags;
 using Domain.Messages;
@@ -14,36 +15,110 @@ namespace Api.UnitTests.Application.ControlPlane;
 
 public class FeatureFlagChangeMessageHandlerTests
 {
+    private const string Region = "us-east-1";
+
     private readonly Mock<ICacheService> _cache = new();
     private readonly Mock<IMessageProducer> _producer = new();
+    private readonly Mock<IFeatureFlagService> _flagService = new();
     private readonly Mock<ILogger<FeatureFlagChangeMessageHandler>> _logger = new();
-    private readonly Mock<IConfiguration> _config = new();
 
-    private FeatureFlagChangeMessageHandler CreateSut()
-        => new(_cache.Object, _producer.Object, _logger.Object, _config.Object);
-
-    [Fact]
-    public async Task HandleAsync_WhenValid_UpsertsAndPublishes()
+    private static IConfiguration BuildConfiguration(string? consistencyMode)
     {
-        _config
-            .Setup(x => x.GetSection(It.IsAny<string>()).Value)
-            .Returns("us-east-1");
-        
-        var sut = CreateSut();
-        var flag = new FeatureFlag();
-        var onFeatureFlagChanged = new OnFeatureFlagChanged(flag, "op", new DataChange(), Guid.NewGuid(), "user");
-        
+        var values = new Dictionary<string, string?>
+        {
+            ["Region"] = Region
+        };
+
+        if (consistencyMode != null)
+        {
+            values["ControlPlane:ConsistencyMode"] = consistencyMode;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private FeatureFlagChangeMessageHandler CreateSut(string? consistencyMode = null)
+        => new(
+            _cache.Object,
+            _producer.Object,
+            _flagService.Object,
+            _logger.Object,
+            BuildConfiguration(consistencyMode));
+
+    private static string BuildMessage(out FeatureFlag flag)
+    {
+        flag = new FeatureFlag
+        {
+            EnvId = Guid.NewGuid(),
+            Key = "my-flag",
+            UpdatedAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+        };
+
+        var onFeatureFlagChanged =
+            new OnFeatureFlagChanged(flag, "op", new DataChange(), Guid.NewGuid(), "user");
+
         var message = new
         {
             notification = onFeatureFlagChanged,
-            region = "us-east-1"
+            region = Region
         };
-        
 
-        await sut.HandleAsync(JsonSerializer.Serialize(message, ReusableJsonSerializerOptions.Web));
+        return JsonSerializer.Serialize(message, ReusableJsonSerializerOptions.Web);
+    }
+
+    [Fact]
+    public async Task HandleAsync_BestEffort_UpsertsAndPublishes()
+    {
+        var sut = CreateSut(consistencyMode: "BestEffort");
+        var message = BuildMessage(out _);
+
+        await sut.HandleAsync(message);
 
         _cache.Verify(x => x.UpsertFlagAsync(It.IsAny<FeatureFlag>()), Times.Once);
-        _producer.Verify(x => x.PublishAsync(Topics.FeatureFlagChange, It.IsAny<FeatureFlag>()), Times.Once);
+        _producer.Verify(
+            x => x.PublishAsync(Topics.FeatureFlagChange, It.IsAny<FeatureFlag>()), Times.Once);
+
+        _cache.Verify(x => x.StageFlagAsync(It.IsAny<FeatureFlag>(), It.IsAny<long>()), Times.Never);
+        _flagService.Verify(
+            x => x.SetPendingAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<FeatureFlag>(), It.IsAny<long>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenModeUnset_DefaultsToBestEffort()
+    {
+        var sut = CreateSut(consistencyMode: null);
+        var message = BuildMessage(out _);
+
+        await sut.HandleAsync(message);
+
+        _cache.Verify(x => x.UpsertFlagAsync(It.IsAny<FeatureFlag>()), Times.Once);
+        _producer.Verify(
+            x => x.PublishAsync(Topics.FeatureFlagChange, It.IsAny<FeatureFlag>()), Times.Once);
+        _cache.Verify(x => x.StageFlagAsync(It.IsAny<FeatureFlag>(), It.IsAny<long>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_GatedCommit_StagesAndSetsPending_DoesNotPublishFlagChange()
+    {
+        var sut = CreateSut(consistencyMode: "GatedCommit");
+        var message = BuildMessage(out var flag);
+        var expectedTs = new DateTimeOffset(flag.UpdatedAt).ToUnixTimeMilliseconds();
+
+        await sut.HandleAsync(message);
+
+        _cache.Verify(
+            x => x.StageFlagAsync(It.Is<FeatureFlag>(f => f.Key == flag.Key), expectedTs),
+            Times.Once);
+        _flagService.Verify(
+            x => x.SetPendingAsync(
+                flag.EnvId, flag.Key, It.Is<FeatureFlag>(f => f.Key == flag.Key), expectedTs),
+            Times.Once);
+
+        _cache.Verify(x => x.UpsertFlagAsync(It.IsAny<FeatureFlag>()), Times.Never);
+        _producer.Verify(
+            x => x.PublishAsync(Topics.FeatureFlagChange, It.IsAny<FeatureFlag>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #14.

Adds `StageFlagAsync`/`CommitFlagAsync` to `ICacheService` (no-op in `NoneCacheService`, broadcast in `CompositeRedisCacheService`; `RedisCacheService` already implements them from B1). Under **GatedCommit** the flag-change handler stages the value to all DC Redis (`ts` from the flag's `UpdatedAt` unix-ms) and writes the Mongo pending change (`SetPendingAsync`), and **withholds** the `Topics.FeatureFlagChange` publish (commit is C3's job). **BestEffort is byte-for-byte unchanged.** Webhook publish unchanged in both modes.

**Verification (unit, mocked deps — no infra):** 4 handler tests + full control-plane suite 50/50; back-end + control-plane build clean. `IFeatureFlagService` already registered in control-plane DI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)