### PR TITLE
✨ Report DC identity + applied watermark in ELS heartbeats (D1)

### DIFF
--- a/modules/back-end/src/Domain/Health/HealthMessage.cs
+++ b/modules/back-end/src/Domain/Health/HealthMessage.cs
@@ -20,8 +20,9 @@ public sealed record HealthMessage
     public string? DcId { get; init; }
 
     /// <summary>
-    /// The highest watermark applied per resource, keyed by resource id. Nullable so
-    /// heartbeats produced before this field existed still deserialize.
+    /// The highest committed flag version (watermark) this pod has applied per
+    /// environment, keyed by environment id. Nullable so heartbeats produced before
+    /// this field existed still deserialize.
     /// </summary>
     public Dictionary<Guid, long>? AppliedWatermarks { get; init; }
 }

--- a/modules/evaluation-server/src/Api/Configuration/ConfigurationExtensions.cs
+++ b/modules/evaluation-server/src/Api/Configuration/ConfigurationExtensions.cs
@@ -29,6 +29,28 @@ public static class ConfigurationExtensions
     }
 
     /// <summary>
+    /// Reads the data center identifier for this pod from configuration key
+    /// "ControlPlane:DcId" (env-var fallback "ControlPlane__DcId" is handled by the
+    /// standard configuration provider). Returns null when unset or empty.
+    /// </summary>
+    public static string? GetDcId(this IConfiguration configuration)
+    {
+        var value = configuration.GetValue<string>("ControlPlane:DcId");
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    /// <summary>
+    /// Reads the region for this pod from configuration key "ControlPlane:Region"
+    /// (env-var fallback "ControlPlane__Region" is handled by the standard configuration
+    /// provider). Returns null when unset or empty.
+    /// </summary>
+    public static string? GetRegion(this IConfiguration configuration)
+    {
+        var value = configuration.GetValue<string>("ControlPlane:Region");
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    /// <summary>
     /// Reads the control plane consistency mode from configuration key
     /// "ControlPlane:ConsistencyMode". Returns <see cref="ConsistencyMode.BestEffort"/>
     /// when the key is unset or cannot be parsed. Never throws.

--- a/modules/evaluation-server/src/Api/Health/HeartbeatService.cs
+++ b/modules/evaluation-server/src/Api/Health/HeartbeatService.cs
@@ -1,10 +1,15 @@
-﻿using Api.Configuration;
+using Api.Configuration;
 using Domain.Health;
 using Domain.Messages;
+using Streaming.Health;
 
 namespace Api.Health;
 
-public class HeartbeatService(IMessageProducer messageProducer, ILogger<HeartbeatService> logger, IConfiguration configuration) : BackgroundService
+public class HeartbeatService(
+    IMessageProducer messageProducer,
+    ILogger<HeartbeatService> logger,
+    IConfiguration configuration,
+    IAppliedWatermarkTracker appliedWatermarkTracker) : BackgroundService
 {
     private readonly Guid _podId = InfrastructureInfo.Id;
 
@@ -18,15 +23,30 @@ public class HeartbeatService(IMessageProducer messageProducer, ILogger<Heartbea
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            await messageProducer.PublishAsync(Topics.PodHeartbeat, new HealthMessage
-            {
-                PodId = _podId.ToString(),
-                Timestamp = DateTimeOffset.UtcNow
-            });
+            await messageProducer.PublishAsync(Topics.PodHeartbeat, BuildHeartbeat());
 
             await Task.Delay(heartbeatTimeSpan, stoppingToken);
         }
 
         logger.LogInformation("HeartbeatService stopping with PodId: {PodId}", _podId);
+    }
+
+    /// <summary>
+    /// Builds the heartbeat payload for the current pod: liveness (PodId/Timestamp),
+    /// placement (DcId/Region from config), and how far this pod is serving per
+    /// environment (AppliedWatermarks). Extracted for unit testing.
+    /// </summary>
+    internal HealthMessage BuildHeartbeat()
+    {
+        var snapshot = appliedWatermarkTracker.Snapshot();
+
+        return new HealthMessage
+        {
+            PodId = _podId.ToString(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Region = configuration.GetRegion(),
+            DcId = configuration.GetDcId(),
+            AppliedWatermarks = snapshot.Count > 0 ? snapshot : null
+        };
     }
 }

--- a/modules/evaluation-server/src/Api/Properties/AssemblyInfo.cs
+++ b/modules/evaluation-server/src/Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Application.IntegrationTests")]

--- a/modules/evaluation-server/src/Domain/Health/HealthMessage.cs
+++ b/modules/evaluation-server/src/Domain/Health/HealthMessage.cs
@@ -24,8 +24,9 @@ namespace Domain.Health
         public string? DcId { get; init; }
 
         /// <summary>
-        /// The highest watermark applied per resource, keyed by resource id. Nullable so
-        /// heartbeats produced before this field existed still deserialize.
+        /// The highest committed flag version (watermark) this pod has applied per
+        /// environment, keyed by environment id. Nullable so heartbeats produced before
+        /// this field existed still deserialize.
         /// </summary>
         public Dictionary<Guid, long>? AppliedWatermarks { get; init; }
     }

--- a/modules/evaluation-server/src/Streaming/Consumers/FeatureFlagChangeMessageConsumer.cs
+++ b/modules/evaluation-server/src/Streaming/Consumers/FeatureFlagChangeMessageConsumer.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Domain.Messages;
 using Microsoft.Extensions.Logging;
 using Streaming.Connections;
+using Streaming.Health;
 using Streaming.Protocol;
 using Streaming.Services;
 
@@ -10,6 +11,7 @@ namespace Streaming.Consumers;
 public class FeatureFlagChangeMessageConsumer(
     IConnectionManager connectionManager,
     IDataSyncService dataSyncService,
+    IAppliedWatermarkTracker appliedWatermarkTracker,
     ILogger<FeatureFlagChangeMessageConsumer> logger)
     : IMessageConsumer
 {
@@ -21,6 +23,15 @@ public class FeatureFlagChangeMessageConsumer(
         var flag = document.RootElement;
 
         var envId = flag.GetProperty("envId").GetGuid();
+
+        // Record the applied watermark for this env. The version is the flag's updatedAt as
+        // unix-ms, consistent with the Redis flag index (see ClientSdkFlag). The tracker keeps
+        // the max per env. Scope: flags only — segments can be folded in later.
+        if (flag.TryGetProperty("updatedAt", out var updatedAt) &&
+            updatedAt.TryGetDateTimeOffset(out var updatedAtValue))
+        {
+            appliedWatermarkTracker.Update(envId, updatedAtValue.ToUnixTimeMilliseconds());
+        }
 
         var connections = connectionManager.GetEnvConnections(envId);
         foreach (var connection in connections)

--- a/modules/evaluation-server/src/Streaming/DependencyInjection/StreamingServiceCollectionExtensions.cs
+++ b/modules/evaluation-server/src/Streaming/DependencyInjection/StreamingServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using Streaming.Connections;
 using Streaming.Consumers;
+using Streaming.Health;
 using Streaming.Messages;
 using Streaming.Services;
 
@@ -46,6 +47,9 @@ public static class StreamingServiceCollectionExtensions
 
         // connection
         services.AddSingleton<IConnectionManager, ConnectionManager>();
+
+        // applied watermark tracker (per-env, highest committed flag version this pod has applied)
+        services.AddSingleton<IAppliedWatermarkTracker, AppliedWatermarkTracker>();
 
         // message handlers
         services

--- a/modules/evaluation-server/src/Streaming/Health/AppliedWatermarkTracker.cs
+++ b/modules/evaluation-server/src/Streaming/Health/AppliedWatermarkTracker.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+
+namespace Streaming.Health;
+
+/// <summary>
+/// Thread-safe <see cref="IAppliedWatermarkTracker"/> backed by a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> that keeps the maximum version
+/// per environment. Registered as a singleton in the eval-server DI.
+/// </summary>
+public sealed class AppliedWatermarkTracker : IAppliedWatermarkTracker
+{
+    private readonly ConcurrentDictionary<Guid, long> _watermarks = new();
+
+    public void Update(Guid envId, long version)
+    {
+        _watermarks.AddOrUpdate(
+            envId,
+            version,
+            (_, existing) => Math.Max(existing, version)
+        );
+    }
+
+    public Dictionary<Guid, long> Snapshot()
+    {
+        // ConcurrentDictionary enumeration is thread-safe and produces a moment-in-time view.
+        return new Dictionary<Guid, long>(_watermarks);
+    }
+}

--- a/modules/evaluation-server/src/Streaming/Health/IAppliedWatermarkTracker.cs
+++ b/modules/evaluation-server/src/Streaming/Health/IAppliedWatermarkTracker.cs
@@ -1,0 +1,30 @@
+namespace Streaming.Health;
+
+/// <summary>
+/// Tracks the highest applied watermark (committed flag version, as unix-ms) this pod
+/// has applied per environment. Used by the heartbeat to report how far this pod is
+/// serving for each environment, for liveness / self-fence / recovery / metrics.
+/// This does NOT gate commits; the commit gate is the control plane's responsibility.
+/// </summary>
+/// <remarks>
+/// Cold-start limitation: the tracker only reflects versions seen since pod start.
+/// It does not query the store/Redis to backfill. Scope is flags only; segments can be
+/// folded in later.
+/// </remarks>
+public interface IAppliedWatermarkTracker
+{
+    /// <summary>
+    /// Records that the pod has applied <paramref name="version"/> for the given
+    /// environment. Keeps the maximum: a lower or equal version never lowers the
+    /// recorded watermark. Thread-safe.
+    /// </summary>
+    /// <param name="envId">The environment id.</param>
+    /// <param name="version">The committed flag version as unix-ms.</param>
+    void Update(Guid envId, long version);
+
+    /// <summary>
+    /// Returns a point-in-time copy of the highest applied watermark per environment,
+    /// keyed by environment id.
+    /// </summary>
+    Dictionary<Guid, long> Snapshot();
+}

--- a/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatServiceTests.cs
+++ b/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatServiceTests.cs
@@ -1,0 +1,112 @@
+using Api.Configuration;
+using Api.Health;
+using Domain.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Streaming.Health;
+
+namespace Application.IntegrationTests.Health;
+
+/// <summary>
+/// Pure unit tests for the heartbeat payload construction (no infra). Exercises
+/// <see cref="HeartbeatService.BuildHeartbeat"/> and the DcId/Region config accessors.
+/// </summary>
+public class HeartbeatServiceTests
+{
+    private sealed class NoopMessageProducer : IMessageProducer
+    {
+        public Task PublishAsync<TMessage>(string topic, TMessage? message) where TMessage : class
+            => Task.CompletedTask;
+    }
+
+    private static IConfiguration Config(params (string Key, string? Value)[] values)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(v => new KeyValuePair<string, string?>(v.Key, v.Value)))
+            .Build();
+
+    private static HeartbeatService CreateSut(IConfiguration configuration, IAppliedWatermarkTracker tracker)
+        => new(
+            new NoopMessageProducer(),
+            NullLogger<HeartbeatService>.Instance,
+            configuration,
+            tracker);
+
+    [Fact]
+    public void BuildHeartbeat_PopulatesDcIdAndRegion_FromConfig()
+    {
+        var config = Config(
+            ("ControlPlane:DcId", "dc-west"),
+            ("ControlPlane:Region", "us-west-2"));
+        var sut = CreateSut(config, new AppliedWatermarkTracker());
+
+        var heartbeat = sut.BuildHeartbeat();
+
+        Assert.Equal("dc-west", heartbeat.DcId);
+        Assert.Equal("us-west-2", heartbeat.Region);
+    }
+
+    [Fact]
+    public void BuildHeartbeat_DcIdAndRegion_AreNull_WhenUnset()
+    {
+        var sut = CreateSut(Config(), new AppliedWatermarkTracker());
+
+        var heartbeat = sut.BuildHeartbeat();
+
+        Assert.Null(heartbeat.DcId);
+        Assert.Null(heartbeat.Region);
+    }
+
+    [Fact]
+    public void BuildHeartbeat_DcIdAndRegion_AreNull_WhenWhitespace()
+    {
+        var config = Config(
+            ("ControlPlane:DcId", "   "),
+            ("ControlPlane:Region", ""));
+        var sut = CreateSut(config, new AppliedWatermarkTracker());
+
+        var heartbeat = sut.BuildHeartbeat();
+
+        Assert.Null(heartbeat.DcId);
+        Assert.Null(heartbeat.Region);
+    }
+
+    [Fact]
+    public void BuildHeartbeat_IncludesAppliedWatermarks_FromTracker()
+    {
+        var tracker = new AppliedWatermarkTracker();
+        var env1 = Guid.NewGuid();
+        var env2 = Guid.NewGuid();
+        tracker.Update(env1, 100);
+        tracker.Update(env1, 50);   // ignored: lower
+        tracker.Update(env2, 300);
+
+        var sut = CreateSut(Config(), tracker);
+
+        var heartbeat = sut.BuildHeartbeat();
+
+        Assert.NotNull(heartbeat.AppliedWatermarks);
+        Assert.Equal(100, heartbeat.AppliedWatermarks![env1]);
+        Assert.Equal(300, heartbeat.AppliedWatermarks![env2]);
+    }
+
+    [Fact]
+    public void BuildHeartbeat_AppliedWatermarks_IsNull_WhenNothingApplied()
+    {
+        var sut = CreateSut(Config(), new AppliedWatermarkTracker());
+
+        var heartbeat = sut.BuildHeartbeat();
+
+        Assert.Null(heartbeat.AppliedWatermarks);
+    }
+
+    [Fact]
+    public void BuildHeartbeat_AlwaysCarries_PodIdAndTimestamp()
+    {
+        var sut = CreateSut(Config(), new AppliedWatermarkTracker());
+
+        var heartbeat = sut.BuildHeartbeat();
+
+        Assert.False(string.IsNullOrEmpty(heartbeat.PodId));
+        Assert.NotEqual(default, heartbeat.Timestamp);
+    }
+}

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Health/AppliedWatermarkTrackerTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Health/AppliedWatermarkTrackerTests.cs
@@ -1,0 +1,94 @@
+using Streaming.Health;
+
+namespace Streaming.UnitTests.Health;
+
+public class AppliedWatermarkTrackerTests
+{
+    private static AppliedWatermarkTracker CreateSut() => new();
+
+    [Fact]
+    public void Snapshot_WhenNothingUpdated_IsEmpty()
+    {
+        var sut = CreateSut();
+
+        var snapshot = sut.Snapshot();
+
+        Assert.Empty(snapshot);
+    }
+
+    [Fact]
+    public void Update_RecordsVersionForEnv()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+
+        sut.Update(envId, 100);
+
+        Assert.Equal(100, sut.Snapshot()[envId]);
+    }
+
+    [Fact]
+    public void Update_KeepsMaximum_WhenLowerVersionArrivesLater()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+
+        sut.Update(envId, 200);
+        sut.Update(envId, 100);
+
+        Assert.Equal(200, sut.Snapshot()[envId]);
+    }
+
+    [Fact]
+    public void Update_AdvancesToMaximum_WhenHigherVersionArrives()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+
+        sut.Update(envId, 100);
+        sut.Update(envId, 300);
+
+        Assert.Equal(300, sut.Snapshot()[envId]);
+    }
+
+    [Fact]
+    public void Update_TracksEnvironmentsIndependently()
+    {
+        var sut = CreateSut();
+        var env1 = Guid.NewGuid();
+        var env2 = Guid.NewGuid();
+
+        sut.Update(env1, 100);
+        sut.Update(env2, 250);
+
+        var snapshot = sut.Snapshot();
+        Assert.Equal(100, snapshot[env1]);
+        Assert.Equal(250, snapshot[env2]);
+    }
+
+    [Fact]
+    public void Snapshot_IsAPointInTimeCopy()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+        sut.Update(envId, 100);
+
+        var snapshot = sut.Snapshot();
+        sut.Update(envId, 200);
+
+        // The previously captured snapshot must not be mutated by later updates.
+        Assert.Equal(100, snapshot[envId]);
+        Assert.Equal(200, sut.Snapshot()[envId]);
+    }
+
+    [Fact]
+    public void Update_ConcurrentWrites_KeepMaximum()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+
+        Parallel.For(1, 1001, i => sut.Update(envId, i));
+
+        Assert.Equal(1000, sut.Snapshot()[envId]);
+    }
+}

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Health/FeatureFlagChangeMessageConsumerWatermarkTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Health/FeatureFlagChangeMessageConsumerWatermarkTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using Streaming.Connections;
+using Streaming.Consumers;
+using Streaming.Health;
+using Streaming.Services;
+
+namespace Streaming.UnitTests.Health;
+
+public class FeatureFlagChangeMessageConsumerWatermarkTests
+{
+    private readonly AppliedWatermarkTracker _tracker = new();
+    private readonly Mock<IConnectionManager> _connectionManager = new();
+    private readonly Mock<IDataSyncService> _dataSyncService = new();
+
+    private FeatureFlagChangeMessageConsumer CreateSut()
+    {
+        // No connections: isolates the watermark-tracking behaviour from the send path.
+        _connectionManager
+            .Setup(m => m.GetEnvConnections(It.IsAny<Guid>()))
+            .Returns(Array.Empty<Connection>());
+
+        return new FeatureFlagChangeMessageConsumer(
+            _connectionManager.Object,
+            _dataSyncService.Object,
+            _tracker,
+            new FakeLogger<FeatureFlagChangeMessageConsumer>());
+    }
+
+    private static string FlagMessage(Guid envId, string updatedAtIso) =>
+        $$"""{"envId":"{{envId}}","key":"flag-1","updatedAt":"{{updatedAtIso}}"}""";
+
+    [Fact]
+    public async Task HandleAsync_RecordsWatermark_AsUpdatedAtUnixMs()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+        var updatedAt = DateTimeOffset.Parse("2026-06-18T00:00:00Z");
+
+        await sut.HandleAsync(FlagMessage(envId, "2026-06-18T00:00:00Z"), CancellationToken.None);
+
+        Assert.Equal(updatedAt.ToUnixTimeMilliseconds(), _tracker.Snapshot()[envId]);
+    }
+
+    [Fact]
+    public async Task HandleAsync_KeepsMaximum_AcrossMultipleVersions()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+
+        var older = DateTimeOffset.Parse("2026-06-18T00:00:00Z");
+        var newer = DateTimeOffset.Parse("2026-06-18T01:00:00Z");
+
+        // Apply newer first, then older — the tracker must keep the maximum.
+        await sut.HandleAsync(FlagMessage(envId, "2026-06-18T01:00:00Z"), CancellationToken.None);
+        await sut.HandleAsync(FlagMessage(envId, "2026-06-18T00:00:00Z"), CancellationToken.None);
+
+        Assert.Equal(newer.ToUnixTimeMilliseconds(), _tracker.Snapshot()[envId]);
+        Assert.NotEqual(older.ToUnixTimeMilliseconds(), _tracker.Snapshot()[envId]);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutUpdatedAt_DoesNotThrowOrRecord()
+    {
+        var sut = CreateSut();
+        var envId = Guid.NewGuid();
+
+        await sut.HandleAsync($$"""{"envId":"{{envId}}","key":"flag-1"}""", CancellationToken.None);
+
+        Assert.Empty(_tracker.Snapshot());
+    }
+}


### PR DESCRIPTION
Closes #18.

Evaluation-server heartbeats now carry **DcId/Region** (config keys `ControlPlane:DcId`/`ControlPlane:Region`, env fallback) — required so the control plane can build a per-DC live set (#15) — and a per-**env** **AppliedWatermarks** map. The watermark is tracked by a singleton `IAppliedWatermarkTracker` updated from the flag-change consumer (version = flag `UpdatedAt` unix-ms).

Per the **Model A** decision (#15/#18), this watermark is **not** a commit gate — it's for self-fence (D5), recovery (E1), and metrics (F1). Flags only for now (segments noted as a follow-up); cold-start limitation accepted (reflects versions seen since pod start). Also corrected the `AppliedWatermarks` XML doc ("resource id" → "environment id").

**Verification (unit, no infra):** Streaming.UnitTests 68/68 (10 new: tracker max-semantics + consumer updates); HeartbeatService payload tests 6/6; eval-server integration suite 71/71. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)