### PR TITLE
✨ Label control-plane Redis instances with DcId (C3a)

### DIFF
--- a/modules/control-plane/src/Api/Infrastructure/Caches/CacheServiceCollectionExtensions.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CacheServiceCollectionExtensions.cs
@@ -48,17 +48,46 @@ public static class CacheServiceCollectionExtensions
 
             services.AddSingleton<IRedisClient>(clients[0]);
 
-            var cacheServices = clients
-                .Select(client => (ICacheService)new RedisCacheService(client))
+            // Pair each cache service with its instance's DcId so broadcast results
+            // can be keyed by DC. The first instance remains the local DC by
+            // convention. An empty DcId falls back to the ordinal index so a
+            // misconfiguration does not crash startup, but it is logged as a warning.
+            var dcCacheServices = clients
+                .Select((client, index) =>
+                {
+                    var dcId = redisInstances[index].DcId;
+                    if (string.IsNullOrWhiteSpace(dcId))
+                    {
+                        dcId = index.ToString();
+                    }
+
+                    return new DcCacheService(dcId, new RedisCacheService(client));
+                })
                 .ToList();
 
             services.AddTransient<ICacheService, RedisCacheService>();
 
             services.AddKeyedSingleton<ICacheService>(
                 "compositeCache",
-                (sp, _) => new CompositeRedisCacheService(
-                    cacheServices,
-                    sp.GetRequiredService<ILogger<CompositeRedisCacheService>>()));
+                (sp, _) =>
+                {
+                    var logger = sp.GetRequiredService<ILogger<CompositeRedisCacheService>>();
+
+                    for (var i = 0; i < redisInstances.Length; i++)
+                    {
+                        if (string.IsNullOrWhiteSpace(redisInstances[i].DcId))
+                        {
+                            logger.LogWarning(
+                                "Redis:Instances[{Index}] has no DcId configured; " +
+                                "falling back to ordinal index '{Index}' as the DC key. " +
+                                "Configure a DcId per instance for stable per-DC broadcast results.",
+                                i,
+                                i);
+                        }
+                    }
+
+                    return new CompositeRedisCacheService(dcCacheServices, logger);
+                });
         }
     }
 }

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -9,8 +9,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Api.Infrastructure.Caches;
 
+/// <summary>
+/// Pairs a <see cref="ICacheService"/> (one DC's Redis) with the id of the DC it
+/// serves, so broadcast results can be keyed by DcId rather than ordinal index.
+/// </summary>
+public record DcCacheService(string DcId, ICacheService Service);
+
 public class CompositeRedisCacheService(
-    IEnumerable<ICacheService> cacheServices,
+    IEnumerable<DcCacheService> cacheServices,
     ILogger<CompositeRedisCacheService> logger) : ICacheService
 {
     // The public ICacheService methods keep returning Task and discard the
@@ -49,11 +55,11 @@ public class CompositeRedisCacheService(
         // Try each instance in order until one succeeds; write-through to all.
         var license = string.Empty;
         var succeeded = false;
-        foreach (var service in cacheServices)
+        foreach (var dc in cacheServices)
         {
             try
             {
-                license = await service.GetOrSetLicenseAsync(workspaceId, licenseGetter);
+                license = await dc.Service.GetOrSetLicenseAsync(workspaceId, licenseGetter);
                 succeeded = true;
                 break;
             }
@@ -65,9 +71,10 @@ public class CompositeRedisCacheService(
             {
                 logger.LogError(
                     ex,
-                    "Redis cache operation '{Operation}' failed for implementation {CacheService}. Trying next instance.",
+                    "Redis cache operation '{Operation}' failed for DC {DcId} (implementation {CacheService}). Trying next instance.",
                     nameof(GetOrSetLicenseAsync),
-                    service.GetType().FullName);
+                    dc.DcId,
+                    dc.Service.GetType().FullName);
             }
         }
 
@@ -93,17 +100,16 @@ public class CompositeRedisCacheService(
     /// <summary>
     /// Broadcasts <paramref name="action"/> to every cache instance, swallowing and
     /// logging per-instance failures so one DC's outage does not fail the others.
-    /// Returns a per-instance success map so callers (e.g. a future commit coordinator)
-    /// can observe partial failure instead of having it silently swallowed.
+    /// Returns a per-DC success map (keyed by DcId) so callers (e.g. a future commit
+    /// coordinator) can observe partial failure instead of having it silently swallowed.
     /// </summary>
-    // TODO: key by DC id once instances carry identity (C2/C3).
     internal async Task<IReadOnlyDictionary<string, bool>> BroadcastAsync(
         Func<ICacheService, Task> action,
         string operationName)
     {
         var instances = cacheServices.ToList();
         var tasks = instances
-            .Select(s => ExecuteSafelyAsync(s, action, operationName))
+            .Select(dc => ExecuteSafelyAsync(dc, action, operationName))
             .ToList();
 
         var outcomes = await Task.WhenAll(tasks);
@@ -111,20 +117,20 @@ public class CompositeRedisCacheService(
         var results = new Dictionary<string, bool>(outcomes.Length);
         for (var i = 0; i < outcomes.Length; i++)
         {
-            results[i.ToString()] = outcomes[i];
+            results[instances[i].DcId] = outcomes[i];
         }
 
         return results;
     }
 
     private async Task<bool> ExecuteSafelyAsync(
-        ICacheService service,
+        DcCacheService dc,
         Func<ICacheService, Task> action,
         string operationName)
     {
         try
         {
-            await action(service);
+            await action(dc.Service);
             return true;
         }
         catch (OperationCanceledException)
@@ -135,9 +141,10 @@ public class CompositeRedisCacheService(
         {
             logger.LogError(
                 ex,
-                "Redis cache broadcast operation '{Operation}' failed for implementation {CacheService}. Continuing.",
+                "Redis cache broadcast operation '{Operation}' failed for DC {DcId} (implementation {CacheService}). Continuing.",
                 operationName,
-                service.GetType().FullName);
+                dc.DcId,
+                dc.Service.GetType().FullName);
             return false;
         }
     }
@@ -165,6 +172,6 @@ public class CompositeRedisCacheService(
     public Task<List<HealthMessage>> GetAllHealthMessages()
     {
         var local = cacheServices.First();
-        return local.GetAllHealthMessages();
+        return local.Service.GetAllHealthMessages();
     }
 }

--- a/modules/control-plane/src/Api/Infrastructure/Caches/RedisInstanceConfig.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/RedisInstanceConfig.cs
@@ -3,6 +3,19 @@ namespace Api.Infrastructure.Caches;
 public class RedisInstanceConfig
 {
     public string ConnectionString { get; set; } = "";
-    
+
     public string? Password { get; set; }
+
+    /// <summary>
+    /// Identifier of the data center this Redis instance belongs to. Used to key
+    /// per-instance broadcast results so a future commit coordinator can map stage
+    /// results back to DCs. When empty, the instance's ordinal index is used as a
+    /// fallback key (and a warning is logged).
+    /// </summary>
+    public string DcId { get; set; } = "";
+
+    /// <summary>
+    /// Optional region label for the data center (informational only).
+    /// </summary>
+    public string? Region { get; set; }
 }

--- a/modules/control-plane/src/Api/appsettings.Development.json
+++ b/modules/control-plane/src/Api/appsettings.Development.json
@@ -45,6 +45,7 @@
   "Redis": {
     "Instances": [
       {
+        "DcId": "dc-local",
         "ConnectionString": "localhost:6379",
         "Password": ""
       }

--- a/modules/control-plane/src/Api/appsettings.json
+++ b/modules/control-plane/src/Api/appsettings.json
@@ -49,6 +49,7 @@
   "Redis": {
     "Instances": [
       {
+        "DcId": "dc-local",
         "ConnectionString": "redis:6379",
         "Password": ""
       }

--- a/modules/control-plane/tests/Api.UnitTests/Application/Caches/CompositeRedisCacheServiceTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/Caches/CompositeRedisCacheServiceTests.cs
@@ -8,12 +8,21 @@ namespace Api.UnitTests.Application.Caches;
 
 public class CompositeRedisCacheServiceTests
 {
+    private const string LocalDcId = "dc-local";
+    private const string RemoteDcId = "dc-remote";
+
     private readonly Mock<ICacheService> _local = new();
     private readonly Mock<ICacheService> _remote = new();
     private readonly Mock<ILogger<CompositeRedisCacheService>> _logger = new();
 
     private CompositeRedisCacheService CreateSut()
-        => new(new[] { _local.Object, _remote.Object }, _logger.Object);
+        => new(
+            new[]
+            {
+                new DcCacheService(LocalDcId, _local.Object),
+                new DcCacheService(RemoteDcId, _remote.Object)
+            },
+            _logger.Object);
 
     [Fact]
     public async Task UpsertPodHeartbeat_WritesToLocalInstanceOnly()
@@ -78,34 +87,39 @@ public class CompositeRedisCacheServiceTests
     }
 
     [Fact]
-    public async Task BroadcastAsync_WhenAllInstancesSucceed_ReturnsTrueForEachIndex()
+    public async Task BroadcastAsync_WhenAllInstancesSucceed_ReturnsTrueForEachDcId()
     {
         var sut = CreateSut();
 
         var result = await sut.BroadcastAsync(_ => Task.CompletedTask, "Op");
 
         Assert.Equal(2, result.Count);
-        Assert.True(result["0"]);
-        Assert.True(result["1"]);
+        Assert.True(result[LocalDcId]);
+        Assert.True(result[RemoteDcId]);
     }
 
     [Fact]
-    public async Task BroadcastAsync_WhenOneInstanceThrows_ReturnsFalseForThatIndexAndTrueForOthers()
+    public async Task BroadcastAsync_WhenOneInstanceThrows_ReturnsFalseForThatDcIdAndTrueForOthers()
     {
-        // _remote is index 1 and is configured to fail for this operation.
+        // The remote DC is configured to fail for this operation.
         var failing = new Mock<ICacheService>();
         failing.Setup(s => s.DeletePodConnection(It.IsAny<Guid>()))
                .ThrowsAsync(new InvalidOperationException("boom"));
 
         var sut = new CompositeRedisCacheService(
-            new[] { _local.Object, failing.Object }, _logger.Object);
+            new[]
+            {
+                new DcCacheService(LocalDcId, _local.Object),
+                new DcCacheService(RemoteDcId, failing.Object)
+            },
+            _logger.Object);
 
         // Should not throw out of the broadcast.
         var result = await sut.BroadcastAsync(
             s => s.DeletePodConnection(Guid.NewGuid()), nameof(ICacheService.DeletePodConnection));
 
         Assert.Equal(2, result.Count);
-        Assert.True(result["0"]);
-        Assert.False(result["1"]);
+        Assert.True(result[LocalDcId]);
+        Assert.False(result[RemoteDcId]);
     }
 }


### PR DESCRIPTION
First half of C3 (#15): the prerequisite that lets the commit coordinator map per-DC stage results to the live set.

- `RedisInstanceConfig` gains `DcId`/`Region`.
- The composite cache pairs each instance's `RedisCacheService` with its `DcId` (`record DcCacheService(string DcId, ICacheService Service)`); empty DcId falls back to ordinal index with a warning.
- `BroadcastAsync` now returns `IReadOnlyDictionary<string,bool>` **keyed by DcId** (resolves C1's `// TODO: key by DC id`). Local-DC (first instance) heartbeat/health behavior unchanged; public `ICacheService` behavior unchanged.

Does **not** include the coordinator itself (C3b) — that's gated on a design checkpoint.

**Verification (unit, no infra):** control-plane Api.UnitTests 50/50 (broadcast now asserts per-DcId results incl. `{dc-remote:false, dc-local:true}`); full back-end + control-plane build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)