### PR TITLE
✨ Pending enumeration + per-DC staged probe (C3b-1)

### DIFF
--- a/modules/back-end/src/Application/Caches/ICacheService.cs
+++ b/modules/back-end/src/Application/Caches/ICacheService.cs
@@ -24,6 +24,13 @@ public interface ICacheService
     /// </summary>
     Task CommitFlagAsync(Guid envId, string flagId, long ts);
 
+    /// <summary>
+    /// Probes whether THIS cache holds the staged version key <c>flag:{id}:v{ts}</c>
+    /// (written by <see cref="StageFlagAsync"/>). Used by the commit coordinator to
+    /// confirm a staged version is present in a given DC's Redis before committing.
+    /// </summary>
+    Task<bool> HasStagedFlagAsync(Guid id, long ts);
+
     Task DeleteFlagAsync(Guid envId, Guid flagId);
 
     Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment);

--- a/modules/back-end/src/Application/Services/IFeatureFlagService.cs
+++ b/modules/back-end/src/Application/Services/IFeatureFlagService.cs
@@ -39,4 +39,11 @@ public interface IFeatureFlagService : IService<FeatureFlag>
     /// returns the new value. No-op when there is no pending change.
     /// </summary>
     Task PromotePendingAsync(Guid envId, string key);
+
+    /// <summary>
+    /// Enumerate every flag (across all envs) that currently has a staged-but-not-committed
+    /// change, i.e. <see cref="FeatureFlag.Pending"/> is not null. Used by the commit
+    /// coordinator to discover the set of pending changes it must reconcile.
+    /// </summary>
+    Task<IReadOnlyList<FeatureFlag>> GetPendingAsync();
 }

--- a/modules/back-end/src/Infrastructure/Caches/None/NoneCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/None/NoneCacheService.cs
@@ -16,6 +16,8 @@ public class NoneCacheService : ICacheService
 
     public Task CommitFlagAsync(Guid envId, string flagId, long ts) => Task.CompletedTask;
 
+    public Task<bool> HasStagedFlagAsync(Guid id, long ts) => Task.FromResult(false);
+
     public Task DeleteFlagAsync(Guid envId, Guid flagId) => Task.CompletedTask;
 
     public Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment) => Task.CompletedTask;

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
@@ -54,6 +54,15 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
         await Redis.SortedSetAddAsync(indexKey, flagId, ts);
     }
 
+    /// <summary>
+    /// Probes whether this Redis holds the staged version value key
+    /// <c>featbit:flag:{id}:v{ts}</c> (B1 stage/commit storage).
+    /// </summary>
+    public Task<bool> HasStagedFlagAsync(Guid id, long ts)
+    {
+        return Redis.KeyExistsAsync(RedisCaches.FlagVersion(id, ts));
+    }
+
     public async Task DeleteFlagAsync(Guid envId, Guid flagId)
     {
         // delete cache

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
@@ -165,4 +165,13 @@ public class FeatureFlagService(AppDbContext dbContext)
 
         await UpdateAsync(flag);
     }
+
+    public async Task<IReadOnlyList<FeatureFlag>> GetPendingAsync()
+    {
+        // Pending is the jsonb column (B4). Postgres translates "pending IS NOT NULL"
+        // for the whole jsonb document, so this is a server-side scan across all envs.
+        return await Queryable
+            .Where(f => f.Pending != null)
+            .ToListAsync();
+    }
 }

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
@@ -182,4 +182,11 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
 
         await UpdateAsync(flag);
     }
+
+    public async Task<IReadOnlyList<FeatureFlag>> GetPendingAsync()
+    {
+        // every flag (across all envs) that currently carries a staged change
+        var flags = await FindManyAsync(x => x.Pending != null);
+        return flags.ToList();
+    }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Caches/RedisHasStagedFlagTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Caches/RedisHasStagedFlagTests.cs
@@ -1,0 +1,90 @@
+using Domain.FeatureFlags;
+using Infrastructure.Caches.Redis;
+using StackExchange.Redis;
+
+namespace Application.IntegrationTests.Caches;
+
+/// <summary>
+/// C3b-1 Part 2: RedisCacheService.HasStagedFlagAsync probes whether THIS Redis holds the
+/// staged version key flag:{id}:v{ts} (written by StageFlagAsync).
+///
+/// Requires a real Redis instance. The orchestrating issue spins one up on a NON-default
+/// port (6383). Override via the C3B1_REDIS env var. Fails loudly if Redis is unreachable.
+/// </summary>
+public class RedisHasStagedFlagTests : IAsyncLifetime
+{
+    private const string DefaultConnection = "localhost:6383";
+
+    private ConnectionMultiplexer? _mux;
+    private RedisCacheService? _sut;
+
+    private static string ConnectionString =>
+        Environment.GetEnvironmentVariable("C3B1_REDIS") ?? DefaultConnection;
+
+    public async Task InitializeAsync()
+    {
+        var options = ConfigurationOptions.Parse(ConnectionString);
+        options.AbortOnConnectFail = false;
+        options.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(options);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{ConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6383:6379 --name c3b1-redis redis:7-alpine " +
+                "(or set the C3B1_REDIS env var).");
+        }
+
+        _sut = new RedisCacheService(new TestRedisClient(_mux));
+    }
+
+    public Task DisposeAsync()
+    {
+        _mux?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HasStagedFlag_True_After_Stage_False_Otherwise()
+    {
+        var sut = _sut!;
+        var db = _mux!.GetDatabase();
+
+        var envId = Guid.NewGuid();
+        var flagId = Guid.NewGuid();
+        var ts = 9_000L;
+
+        // not staged yet
+        Assert.False(await sut.HasStagedFlagAsync(flagId, ts));
+
+        // stage the version
+        await sut.StageFlagAsync(NewFlag(envId, flagId, ts), ts);
+
+        // present for this exact (id, ts)
+        Assert.True(await sut.HasStagedFlagAsync(flagId, ts));
+
+        // a different ts for the same flag is NOT staged
+        Assert.False(await sut.HasStagedFlagAsync(flagId, ts + 1));
+
+        // a different flag id is NOT staged
+        Assert.False(await sut.HasStagedFlagAsync(Guid.NewGuid(), ts));
+
+        // cleanup
+        await db.KeyDeleteAsync(RedisCaches.FlagVersion(flagId, ts));
+    }
+
+    private static FeatureFlag NewFlag(Guid envId, Guid flagId, long ts) => new()
+    {
+        Id = flagId,
+        EnvId = envId,
+        UpdatedAt = DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime
+    };
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase();
+    }
+}

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagGetPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagGetPendingPostgresTests.cs
@@ -1,0 +1,139 @@
+using Domain.FeatureFlags;
+using Domain.Utils;
+using Infrastructure.Persistence.EntityFrameworkCore;
+using Infrastructure.Services.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Application.IntegrationTests.FeatureFlags;
+
+/// <summary>
+/// C3b-1 Part 1 (Postgres/EF): GetPendingAsync filters on the jsonb "pending" column
+/// (Where(f => f.Pending != null)) and that filter must translate to a server-side scan.
+/// Enumerates every flag (across all envs) with a staged change; excludes committed-only flags.
+///
+/// Integration test against a real Postgres instance (throwaway container on port 5435).
+/// EnsureCreated() materializes the EF model (incl. committed_version/pending). Fails loudly
+/// if no Postgres is reachable.
+/// </summary>
+public sealed class FeatureFlagGetPendingPostgresTests : IAsyncLifetime
+{
+    private const string BaseConnectionString =
+        "Host=localhost;Port=5435;Database=featbit;Username=postgres;Password=please_change_me";
+
+    private readonly string _dbName = $"featbit_c3b1_test_{Guid.NewGuid():N}";
+    private string _connectionString = null!;
+    private NpgsqlDataSource _dataSource = null!;
+    private AppDbContext _dbContext = null!;
+    private FeatureFlagService _sut = null!;
+
+    public async Task InitializeAsync()
+    {
+        // fail fast if Postgres is not available. Probe the always-present "postgres" db.
+        var probeConnectionString = new NpgsqlConnectionStringBuilder(BaseConnectionString)
+        {
+            Database = "postgres"
+        }.ConnectionString;
+        await using (var probe = new NpgsqlConnection(probeConnectionString))
+        {
+            await probe.OpenAsync();
+        }
+
+        _connectionString = new NpgsqlConnectionStringBuilder(BaseConnectionString)
+        {
+            Database = _dbName
+        }.ConnectionString;
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(_connectionString);
+        dataSourceBuilder
+            .EnableDynamicJson()
+            .ConfigureJsonOptions(ReusableJsonSerializerOptions.Web);
+        _dataSource = dataSourceBuilder.Build();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(_dataSource)
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        _dbContext = new AppDbContext(options);
+
+        await _dbContext.Database.EnsureCreatedAsync();
+
+        _sut = new FeatureFlagService(_dbContext);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_dbContext != null!)
+        {
+            await _dbContext.Database.EnsureDeletedAsync();
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_dataSource != null!)
+        {
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    private static FeatureFlag CreateFlag(Guid envId, string key, bool isEnabled)
+    {
+        var enabledVariationId = Guid.NewGuid().ToString();
+        var disabledVariationId = Guid.NewGuid().ToString();
+
+        var variations = new List<Variation>
+        {
+            new() { Id = enabledVariationId, Name = "true", Value = "true" },
+            new() { Id = disabledVariationId, Name = "false", Value = "false" }
+        };
+
+        return new FeatureFlag(
+            envId: envId,
+            name: key,
+            description: string.Empty,
+            key: key,
+            isEnabled: isEnabled,
+            variationType: "boolean",
+            variations: variations,
+            disabledVariationId: disabledVariationId,
+            enabledVariationId: enabledVariationId,
+            tags: [],
+            currentUserId: Guid.NewGuid()
+        );
+    }
+
+    [Fact]
+    public async Task GetPending_Returns_Only_Flags_With_Pending_Across_All_Envs()
+    {
+        var envA = Guid.NewGuid();
+        var envB = Guid.NewGuid();
+
+        await _sut.AddOneAsync(CreateFlag(envA, "a-committed-only", isEnabled: false));
+
+        await _sut.AddOneAsync(CreateFlag(envA, "a-pending", isEnabled: false));
+        await _sut.SetPendingAsync(envA, "a-pending", CreateFlag(envA, "a-pending", true), version: 2);
+
+        await _sut.AddOneAsync(CreateFlag(envB, "b-pending", isEnabled: false));
+        await _sut.SetPendingAsync(envB, "b-pending", CreateFlag(envB, "b-pending", true), version: 7);
+
+        var pending = await _sut.GetPendingAsync();
+
+        Assert.Equal(2, pending.Count);
+        Assert.All(pending, f => Assert.NotNull(f.Pending));
+
+        var keys = pending.Select(f => f.Key).OrderBy(k => k).ToArray();
+        Assert.Equal(new[] { "a-pending", "b-pending" }, keys);
+    }
+
+    [Fact]
+    public async Task GetPending_Returns_Empty_When_No_Flags_Have_Pending()
+    {
+        var envId = Guid.NewGuid();
+        await _sut.AddOneAsync(CreateFlag(envId, "no-pending-1", isEnabled: true));
+        await _sut.AddOneAsync(CreateFlag(envId, "no-pending-2", isEnabled: false));
+
+        var pending = await _sut.GetPendingAsync();
+
+        Assert.Empty(pending);
+    }
+}

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagGetPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagGetPendingTests.cs
@@ -1,0 +1,111 @@
+using Domain.FeatureFlags;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using Microsoft.Extensions.Options;
+
+namespace Application.IntegrationTests.FeatureFlags;
+
+/// <summary>
+/// C3b-1 Part 1 (Mongo): GetPendingAsync enumerates every flag (across all envs) whose
+/// Pending != null, and excludes flags with no staged change.
+///
+/// Integration test against a real MongoDB instance. Uses a UNIQUE throwaway database that
+/// is dropped on dispose. Fails loudly if no Mongo is reachable.
+/// </summary>
+public sealed class FeatureFlagGetPendingTests : IAsyncLifetime
+{
+    private const string ConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
+
+    private readonly string _dbName = $"featbit_c3b1_test_{Guid.NewGuid():N}";
+    private MongoDbClient _mongoDb = null!;
+    private FeatureFlagService _sut = null!;
+
+    public async Task InitializeAsync()
+    {
+        var options = Options.Create(new MongoDbOptions
+        {
+            ConnectionString = ConnectionString,
+            Database = _dbName
+        });
+
+        _mongoDb = new MongoDbClient(options);
+
+        // fail fast if Mongo is not available
+        await _mongoDb.Database.RunCommandAsync<MongoDB.Bson.BsonDocument>(
+            new MongoDB.Bson.BsonDocument("ping", 1)
+        );
+
+        _sut = new FeatureFlagService(_mongoDb);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _mongoDb.Database.Client.DropDatabaseAsync(_dbName);
+    }
+
+    private static FeatureFlag CreateFlag(Guid envId, string key, bool isEnabled)
+    {
+        var enabledVariationId = Guid.NewGuid().ToString();
+        var disabledVariationId = Guid.NewGuid().ToString();
+
+        var variations = new List<Variation>
+        {
+            new() { Id = enabledVariationId, Name = "true", Value = "true" },
+            new() { Id = disabledVariationId, Name = "false", Value = "false" }
+        };
+
+        return new FeatureFlag(
+            envId: envId,
+            name: key,
+            description: string.Empty,
+            key: key,
+            isEnabled: isEnabled,
+            variationType: "boolean",
+            variations: variations,
+            disabledVariationId: disabledVariationId,
+            enabledVariationId: enabledVariationId,
+            tags: [],
+            currentUserId: Guid.NewGuid()
+        );
+    }
+
+    [Fact]
+    public async Task GetPending_Returns_Only_Flags_With_Pending_Across_All_Envs()
+    {
+        var envA = Guid.NewGuid();
+        var envB = Guid.NewGuid();
+
+        // env A: one committed-only flag + one with a pending change
+        var aCommittedOnly = CreateFlag(envA, "a-committed-only", isEnabled: false);
+        await _sut.AddOneAsync(aCommittedOnly);
+
+        var aPending = CreateFlag(envA, "a-pending", isEnabled: false);
+        await _sut.AddOneAsync(aPending);
+        await _sut.SetPendingAsync(envA, "a-pending", CreateFlag(envA, "a-pending", true), version: 2);
+
+        // env B: one with a pending change (proves "across all envs")
+        var bPending = CreateFlag(envB, "b-pending", isEnabled: false);
+        await _sut.AddOneAsync(bPending);
+        await _sut.SetPendingAsync(envB, "b-pending", CreateFlag(envB, "b-pending", true), version: 7);
+
+        var pending = await _sut.GetPendingAsync();
+
+        Assert.Equal(2, pending.Count);
+        Assert.All(pending, f => Assert.NotNull(f.Pending));
+
+        var keys = pending.Select(f => f.Key).OrderBy(k => k).ToArray();
+        Assert.Equal(new[] { "a-pending", "b-pending" }, keys);
+    }
+
+    [Fact]
+    public async Task GetPending_Returns_Empty_When_No_Flags_Have_Pending()
+    {
+        var envId = Guid.NewGuid();
+        await _sut.AddOneAsync(CreateFlag(envId, "no-pending-1", isEnabled: true));
+        await _sut.AddOneAsync(CreateFlag(envId, "no-pending-2", isEnabled: false));
+
+        var pending = await _sut.GetPendingAsync();
+
+        Assert.Empty(pending);
+    }
+}

--- a/modules/control-plane/ControlPlane.slnx
+++ b/modules/control-plane/ControlPlane.slnx
@@ -7,5 +7,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Api.UnitTests/Api.UnitTests.csproj" />
+    <Project Path="tests/Api.IntegrationTests/Api.IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -32,6 +32,15 @@ public class CompositeRedisCacheService(
     public Task CommitFlagAsync(Guid envId, string flagId, long ts) =>
         BroadcastAsync(s => s.CommitFlagAsync(envId, flagId, ts), nameof(CommitFlagAsync));
 
+    // ICacheService probe: returns the LOCAL DC's result (first instance), consistent with
+    // the heartbeat/health local-first convention above. This is NOT the coordinator API —
+    // the coordinator must use GetStagedDcsAsync to see EVERY DC's staged presence.
+    public Task<bool> HasStagedFlagAsync(Guid id, long ts)
+    {
+        var local = cacheServices.First();
+        return local.Service.HasStagedFlagAsync(id, ts);
+    }
+
     public Task DeleteFlagAsync(Guid envId, Guid flagId) =>
         BroadcastAsync(s => s.DeleteFlagAsync(envId, flagId), nameof(DeleteFlagAsync));
 
@@ -121,6 +130,52 @@ public class CompositeRedisCacheService(
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Coordinator-facing probe: returns, per <see cref="DcCacheService.DcId"/>, whether that
+    /// DC's Redis holds the staged version <c>flag:{id}:v{ts}</c>. Iterates every configured
+    /// DC (unlike the local-first <see cref="HasStagedFlagAsync"/>) with the same
+    /// swallow-and-continue resilience as <see cref="BroadcastAsync"/>: a DC whose probe throws
+    /// is reported as <c>false</c> rather than failing the whole call.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, bool>> GetStagedDcsAsync(Guid id, long ts)
+    {
+        var instances = cacheServices.ToList();
+        var tasks = instances
+            .Select(dc => ProbeStagedSafelyAsync(dc, id, ts))
+            .ToList();
+
+        var outcomes = await Task.WhenAll(tasks);
+
+        var results = new Dictionary<string, bool>(outcomes.Length);
+        for (var i = 0; i < outcomes.Length; i++)
+        {
+            results[instances[i].DcId] = outcomes[i];
+        }
+
+        return results;
+    }
+
+    private async Task<bool> ProbeStagedSafelyAsync(DcCacheService dc, Guid id, long ts)
+    {
+        try
+        {
+            return await dc.Service.HasStagedFlagAsync(id, ts);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Staged-flag probe failed for DC {DcId} (implementation {CacheService}). Reporting not-staged.",
+                dc.DcId,
+                dc.Service.GetType().FullName);
+            return false;
+        }
     }
 
     private async Task<bool> ExecuteSafelyAsync(

--- a/modules/control-plane/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/modules/control-plane/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Api\Api.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/modules/control-plane/tests/Api.IntegrationTests/Caches/CompositeRedisGetStagedDcsTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/Caches/CompositeRedisGetStagedDcsTests.cs
@@ -1,0 +1,101 @@
+using Api.Infrastructure.Caches;
+using Domain.FeatureFlags;
+using Infrastructure.Caches.Redis;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+
+namespace Api.IntegrationTests.Caches;
+
+/// <summary>
+/// C3b-1 Part 2 (coordinator API): CompositeRedisCacheService.GetStagedDcsAsync returns, per
+/// DcId, whether THAT DC's Redis holds the staged version flag:{id}:v{ts}.
+///
+/// Two DCs are simulated by two RedisCacheService instances bound to two logical Redis DB
+/// indexes (0 = west, 1 = east) on a single throwaway Redis. Staging into west's DB only must
+/// produce a per-DcId map showing present in west and absent in east.
+///
+/// Requires a real Redis on a NON-default port (6383). Override via C3B1_REDIS env var. Fails
+/// loudly if Redis is unreachable.
+/// </summary>
+public class CompositeRedisGetStagedDcsTests : IAsyncLifetime
+{
+    private const string DefaultConnection = "localhost:6383";
+    private const string WestDcId = "dc-west";
+    private const string EastDcId = "dc-east";
+
+    private ConnectionMultiplexer? _mux;
+
+    private static string ConnectionString =>
+        Environment.GetEnvironmentVariable("C3B1_REDIS") ?? DefaultConnection;
+
+    public async Task InitializeAsync()
+    {
+        var options = ConfigurationOptions.Parse(ConnectionString);
+        options.AbortOnConnectFail = false;
+        options.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(options);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{ConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6383:6379 --name c3b1-redis redis:7-alpine " +
+                "(or set the C3B1_REDIS env var).");
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _mux?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task GetStagedDcs_ReportsPerDc_StagedPresence()
+    {
+        // west -> logical db 0, east -> logical db 1 (independent keyspaces on one server)
+        var west = new RedisCacheService(new TestRedisClient(_mux!, db: 0));
+        var east = new RedisCacheService(new TestRedisClient(_mux!, db: 1));
+
+        var sut = new CompositeRedisCacheService(
+            new[]
+            {
+                new DcCacheService(WestDcId, west),
+                new DcCacheService(EastDcId, east)
+            },
+            NullLogger<CompositeRedisCacheService>.Instance);
+
+        var envId = Guid.NewGuid();
+        var flagId = Guid.NewGuid();
+        var ts = 12_000L;
+
+        // stage the version into WEST's Redis only
+        await west.StageFlagAsync(NewFlag(envId, flagId, ts), ts);
+
+        var map = await sut.GetStagedDcsAsync(flagId, ts);
+
+        Assert.Equal(2, map.Count);
+        Assert.True(map[WestDcId], "west staged the version, so its DC should report present");
+        Assert.False(map[EastDcId], "east never staged the version, so its DC should report absent");
+
+        // sanity: the ICacheService probe is local-first (west = first instance) -> true
+        Assert.True(await sut.HasStagedFlagAsync(flagId, ts));
+
+        // cleanup
+        await _mux!.GetDatabase(0).KeyDeleteAsync(RedisCaches.FlagVersion(flagId, ts));
+    }
+
+    private static FeatureFlag NewFlag(Guid envId, Guid flagId, long ts) => new()
+    {
+        Id = flagId,
+        EnvId = envId,
+        UpdatedAt = DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime
+    };
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase(db);
+    }
+}


### PR DESCRIPTION
Part of **#15 (C3)** — the read capabilities the commit coordinator (C3b-2) needs. (#15 stays open until C3b-2.)

- **Pending enumeration:** `IFeatureFlagService.GetPendingAsync()` → all flags where `Pending != null` (Mongo filter + EF `Where(f => f.Pending != null)`, verified translating against Postgres).
- **Per-DC staged probe:** `ICacheService.HasStagedFlagAsync(id, ts)` (Redis `KeyExists` on `flag:{id}:v{ts}`; None=false; composite=local-DC); plus the coordinator-facing `CompositeRedisCacheService.GetStagedDcsAsync(id, ts)` → per-**DcId** existence map (swallow-and-continue; a failed probe counts as absent).

Implements the confirmed **probe** (decision A) + **DB-scan** (decision B) from the C3b design.

Also adds a control-plane `Api.IntegrationTests` project (the control plane had none).

**Verification (real infra):** 5 back-end integration (2 Mongo + 2 Postgres GetPending, 1 Redis HasStagedFlag) + 1 control-plane integration (GetStagedDcs per-DC) pass; CP unit 50/50; full back-end + control-plane builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)