### PR TITLE
✨ Commit coordinator (C3b-2) — completes C3

### DIFF
--- a/modules/back-end/src/Application/Services/IFeatureFlagService.cs
+++ b/modules/back-end/src/Application/Services/IFeatureFlagService.cs
@@ -34,11 +34,17 @@ public interface IFeatureFlagService : IService<FeatureFlag>
     Task SetPendingAsync(Guid envId, string key, FeatureFlag pendingValue, long version);
 
     /// <summary>
-    /// Promote the staged pending change to committed for the flag identified by
+    /// Optimistically promote the staged pending change to committed for the flag identified by
     /// <paramref name="envId"/>/<paramref name="key"/>, so <see cref="GetCommittedAsync"/>
-    /// returns the new value. No-op when there is no pending change.
+    /// returns the new value. The promotion happens ONLY if the stored
+    /// <see cref="PendingFlagChange.Version"/> still equals <paramref name="expectedVersion"/>;
+    /// otherwise it is a no-op. This version guard prevents a lost update when a racing
+    /// <see cref="SetPendingAsync"/> replaces the pending change between the coordinator reading it
+    /// and committing it (#33), and lets the coordinator skip stale promotions (#34).
     /// </summary>
-    Task PromotePendingAsync(Guid envId, string key);
+    /// <returns><c>true</c> if the pending change was promoted; <c>false</c> if there was no
+    /// pending change or its version no longer matched <paramref name="expectedVersion"/>.</returns>
+    Task<bool> PromotePendingAsync(Guid envId, string key, long expectedVersion);
 
     /// <summary>
     /// Enumerate every flag (across all envs) that currently has a staged-but-not-committed

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
@@ -155,15 +155,29 @@ public class FeatureFlagService(AppDbContext dbContext)
         await UpdateAsync(flag);
     }
 
-    public async Task PromotePendingAsync(Guid envId, string key)
+    public async Task<bool> PromotePendingAsync(Guid envId, string key, long expectedVersion)
     {
         var flag = await GetAsync(envId, key);
+
+        // Version guard (#33/#34): only promote if the pending change still matches the version
+        // the caller observed. If it was replaced by a racing SetPendingAsync (different version)
+        // or already promoted (null), do nothing.
+        if (flag.Pending?.Version != expectedVersion)
+        {
+            return false;
+        }
 
         // promote pending -> committed, then persist the full row so the committed
         // value advances and the pending slot is cleared.
         flag.PromotePending();
 
+        // NOTE (#33): without a rowversion/concurrency token there is a residual non-atomic window
+        // between the GetAsync above and SaveChanges here — a racing SetPendingAsync committing in
+        // that window could be overwritten. The in-memory version check narrows but does not close
+        // it for the EF provider; closing it requires an optimistic-concurrency token (tracked in
+        // #33). The Mongo provider closes it via a version-filtered ReplaceOneAsync.
         await UpdateAsync(flag);
+        return true;
     }
 
     public async Task<IReadOnlyList<FeatureFlag>> GetPendingAsync()

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
@@ -172,15 +172,34 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
         await Collection.UpdateOneAsync(filter, update);
     }
 
-    public async Task PromotePendingAsync(Guid envId, string key)
+    public async Task<bool> PromotePendingAsync(Guid envId, string key, long expectedVersion)
     {
         var flag = await GetAsync(envId, key);
+
+        // Version guard (#33/#34): only promote if the pending change we are about to commit is
+        // still the one the caller observed. If a racing SetPendingAsync replaced it (different
+        // version) or it was already promoted (null), do nothing.
+        if (flag.Pending?.Version != expectedVersion)
+        {
+            return false;
+        }
 
         // promote pending -> committed in-memory, then persist the full document so the
         // committed value advances and the pending slot is cleared atomically.
         flag.PromotePending();
 
-        await UpdateAsync(flag);
+        // Optimistic replace filtered on Pending.Version == expectedVersion: if another writer
+        // staged a new pending version after our read, the filter no longer matches and the
+        // replace is a no-op (MatchedCount == 0), so a concurrent SetPendingAsync cannot be lost
+        // (#33).
+        var filter = Builders<FeatureFlag>.Filter.And(
+            Builders<FeatureFlag>.Filter.Eq(x => x.EnvId, envId),
+            Builders<FeatureFlag>.Filter.Eq(x => x.Key, key),
+            Builders<FeatureFlag>.Filter.Eq(x => x.Pending!.Version, expectedVersion)
+        );
+
+        var result = await Collection.ReplaceOneAsync(filter, flag);
+        return result.MatchedCount > 0;
     }
 
     public async Task<IReadOnlyList<FeatureFlag>> GetPendingAsync()

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingPostgresTests.cs
@@ -141,8 +141,9 @@ public sealed class FeatureFlagCommittedPendingPostgresTests : IAsyncLifetime
         Assert.Equal(2, raw.Pending!.Version);
         Assert.True(raw.Pending.Value.IsEnabled);
 
-        // Act 2: promote pending -> committed
-        await _sut.PromotePendingAsync(_envId, key);
+        // Act 2: promote pending -> committed (guarded on the staged version 2)
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 2);
+        Assert.True(promoted);
 
         // Assert 2: committed read now returns the NEW value and advanced version
         var afterPromote = await _sut.GetCommittedAsync(_envId, key);
@@ -178,11 +179,36 @@ public sealed class FeatureFlagCommittedPendingPostgresTests : IAsyncLifetime
         committed.CommittedVersion = 3;
         await _sut.AddOneAsync(committed);
 
-        await _sut.PromotePendingAsync(_envId, key);
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 4);
+        Assert.False(promoted);
 
         var read = await _sut.GetCommittedAsync(_envId, key);
         Assert.False(read.IsEnabled);
         Assert.Equal(3, read.CommittedVersion);
         Assert.Null(read.Pending);
+    }
+
+    [Fact]
+    public async Task PromotePending_Is_NoOp_When_Version_Mismatch()
+    {
+        // a stale coordinator (expecting v2) must NOT clobber a newer staged pending (v3) — #33
+        const string key = "b4-promote-version-mismatch";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        await _sut.SetPendingAsync(_envId, key, pendingValue, version: 3);
+
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 2);
+        Assert.False(promoted);
+
+        var read = await _sut.GetCommittedAsync(_envId, key);
+        Assert.False(read.IsEnabled);
+        Assert.Equal(1, read.CommittedVersion);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
     }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingTests.cs
@@ -98,8 +98,9 @@ public sealed class FeatureFlagCommittedPendingTests : IAsyncLifetime
         Assert.Equal(2, raw.Pending!.Version);
         Assert.True(raw.Pending.Value.IsEnabled);
 
-        // Act 2: promote pending -> committed
-        await _sut.PromotePendingAsync(_envId, key);
+        // Act 2: promote pending -> committed (guarded on the staged version 2)
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 2);
+        Assert.True(promoted);
 
         // Assert 2: committed read now returns the NEW value and advanced version
         var afterPromote = await _sut.GetCommittedAsync(_envId, key);
@@ -135,11 +136,38 @@ public sealed class FeatureFlagCommittedPendingTests : IAsyncLifetime
         committed.CommittedVersion = 3;
         await _sut.AddOneAsync(committed);
 
-        await _sut.PromotePendingAsync(_envId, key);
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 4);
+        Assert.False(promoted);
 
         var read = await _sut.GetCommittedAsync(_envId, key);
         Assert.False(read.IsEnabled);
         Assert.Equal(3, read.CommittedVersion);
         Assert.Null(read.Pending);
+    }
+
+    [Fact]
+    public async Task PromotePending_Is_NoOp_When_Version_Mismatch()
+    {
+        // a stale coordinator (expecting v2) must NOT clobber a newer staged pending (v3) — #33
+        const string key = "b3-promote-version-mismatch";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        await _sut.SetPendingAsync(_envId, key, pendingValue, version: 3);
+
+        // coordinator tries to promote expecting the older version 2 -> guard rejects it
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 2);
+        Assert.False(promoted);
+
+        // committed value untouched and the v3 pending is still intact
+        var read = await _sut.GetCommittedAsync(_envId, key);
+        Assert.False(read.IsEnabled);
+        Assert.Equal(1, read.CommittedVersion);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
     }
 }

--- a/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
@@ -1,0 +1,202 @@
+using Application.Caches;
+using Application.Configuration;
+using Application.ControlPlane;
+using Application.Services;
+using Api.Infrastructure.Caches;
+using Domain.FeatureFlags;
+using Domain.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Application.ControlPlane;
+
+/// <summary>
+/// C3b-2 commit coordinator. Under <see cref="ConsistencyMode.GatedCommit"/> this periodically
+/// reconciles pending (staged-but-not-committed) flag changes: a pending version is committed
+/// (its committed pointer/index advanced in every DC's Redis, the Mongo/EF pending promoted to
+/// committed, and the change published to the evaluation-server topic) only once EVERY currently
+/// live DC has that exact version staged in its own Redis.
+///
+/// Gate model (locked design): the control plane probes each live DC's Redis directly
+/// (<see cref="CompositeRedisCacheService.GetStagedDcsAsync"/>) — "live" = a DC with at least one
+/// unexpired lease in <see cref="ILeaseStore"/>. The pending set is enumerated via a DB scan
+/// (<see cref="IFeatureFlagService.GetPendingAsync"/>); commit granularity is per-flag.
+///
+/// Idempotent + crash-safe: re-running a tick is a no-op once a flag is committed — the commit
+/// broadcast and the version-guarded promote both no-op when already applied.
+///
+/// TODO: single-instance/leader election if the control plane runs multiple replicas. Today
+/// multiple replicas would each run this loop; the commit + version-guarded promote are idempotent
+/// so this is safe (at worst duplicate publishes), but a leader election would avoid the redundant
+/// work. Out of scope for C3b-2; tracked as a follow-up.
+/// </summary>
+public sealed class CommitCoordinatorWorker : BackgroundService
+{
+    /// <summary>
+    /// Default interval between coordinator ticks when not overridden via
+    /// <c>ControlPlane:CommitCoordinator:IntervalSeconds</c>.
+    /// </summary>
+    public static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(5);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ICacheService _compositeCache;
+    private readonly IMessageProducer _messageProducer;
+    private readonly bool _enabled;
+    private readonly TimeSpan _interval;
+    private readonly ILogger<CommitCoordinatorWorker> _logger;
+
+    public CommitCoordinatorWorker(
+        IServiceScopeFactory scopeFactory,
+        [FromKeyedServices("compositeCache")] ICacheService compositeCache,
+        IMessageProducer messageProducer,
+        IConfiguration configuration,
+        ILogger<CommitCoordinatorWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _compositeCache = compositeCache;
+        _messageProducer = messageProducer;
+        _logger = logger;
+        _enabled = configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit;
+
+        var seconds = configuration.GetValue<int?>("ControlPlane:CommitCoordinator:IntervalSeconds");
+        _interval = seconds is > 0
+            ? TimeSpan.FromSeconds(seconds.Value)
+            : DefaultInterval;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_enabled)
+        {
+            _logger.LogInformation(
+                "Commit coordinator disabled (consistency mode is not GatedCommit).");
+            return;
+        }
+
+        using var timer = new PeriodicTimer(_interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                var committed = await RunOnceAsync(stoppingToken);
+                if (committed > 0)
+                {
+                    _logger.LogInformation(
+                        "Commit coordinator committed {CommittedCount} pending flag change(s).",
+                        committed);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // ignore cancellation from the timer loop itself
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while running the commit coordinator tick.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs a single coordinator tick and returns the number of flags committed. Exposed so it
+    /// can be invoked directly (e.g. by integration tests) without waiting on the periodic timer.
+    ///
+    /// For each pending flag whose pending version is newer than its committed version, if every
+    /// currently live DC has that version staged, the flag is committed across all DCs, its pending
+    /// is promoted (version-guarded), and the change is published to the evaluation-server topic.
+    /// Otherwise the flag is left pending and retried on the next tick.
+    /// </summary>
+    public async Task<int> RunOnceAsync(CancellationToken cancellationToken = default)
+    {
+        // IFeatureFlagService is a scoped (per-request) service in DI; resolve it inside a scope so
+        // the singleton BackgroundService does not capture a scoped/disposed instance.
+        using var scope = _scopeFactory.CreateScope();
+        var featureFlagService = scope.ServiceProvider.GetRequiredService<IFeatureFlagService>();
+        var leaseStore = scope.ServiceProvider.GetRequiredService<ILeaseStore>();
+
+        var pending = await featureFlagService.GetPendingAsync();
+        if (pending.Count == 0)
+        {
+            return 0;
+        }
+
+        // Live DCs = distinct DcIds that currently hold at least one unexpired lease.
+        var liveSet = await leaseStore.GetLiveSetAsync(DateTimeOffset.UtcNow);
+        var liveDcs = liveSet
+            .Select(lease => lease.DcId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct()
+            .ToList();
+
+        if (liveDcs.Count == 0)
+        {
+            // No live DC to serve to -> nothing to commit this tick.
+            return 0;
+        }
+
+        // GetStagedDcsAsync is a coordinator-only probe that lives on CompositeRedisCacheService,
+        // not on the ICacheService contract. In the Redis path the keyed "compositeCache" service
+        // is always a CompositeRedisCacheService; guard the cast so a misconfiguration (e.g. None
+        // cache) degrades to a clear log instead of a crash loop.
+        if (_compositeCache is not CompositeRedisCacheService composite)
+        {
+            _logger.LogWarning(
+                "Commit coordinator requires the composite Redis cache (got {CacheType}); skipping tick.",
+                _compositeCache.GetType().FullName);
+            return 0;
+        }
+
+        var count = 0;
+
+        foreach (var flag in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var pendingChange = flag.Pending;
+            if (pendingChange == null)
+            {
+                continue;
+            }
+
+            var version = pendingChange.Version;
+
+            // Monotonicity (#34): never commit a version that is not strictly newer than what is
+            // already committed. Skips stale/duplicate pending rows.
+            if (version <= flag.CommittedVersion)
+            {
+                continue;
+            }
+
+            var stagedMap = await composite.GetStagedDcsAsync(flag.Id, version);
+
+            // Gate: EVERY live DC must have this exact version staged. A DC missing from the map,
+            // or present-but-false, blocks the commit (we retry next tick once it catches up).
+            var allLiveStaged = liveDcs.All(dc => stagedMap.TryGetValue(dc, out var staged) && staged);
+            if (!allLiveStaged)
+            {
+                continue;
+            }
+
+            // Broadcast the commit to all DCs: advance the committed pointer + index everywhere.
+            await composite.CommitFlagAsync(flag.EnvId, flag.Id.ToString(), version);
+
+            // Version-guarded promote of the DB pending -> committed. If a racing SetPendingAsync
+            // replaced the pending version since GetPendingAsync read it, the guard makes this a
+            // no-op and we do NOT publish a stale value.
+            var promoted = await featureFlagService.PromotePendingAsync(flag.EnvId, flag.Key, version);
+            if (!promoted)
+            {
+                continue;
+            }
+
+            // Publish the newly committed value to the evaluation-server topic. The pending value
+            // IS the new committed state; it carries the same shape the BestEffort path publishes.
+            await _messageProducer.PublishAsync(Topics.FeatureFlagChange, pendingChange.Value);
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/modules/control-plane/src/Api/Infrastructure/Persistence/DbServiceCollectionExtensions.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Persistence/DbServiceCollectionExtensions.cs
@@ -33,6 +33,9 @@ public static class DbServiceCollectionExtensions
             services.AddTransient<IFeatureFlagService, MongoServices.FeatureFlagService>();
             services.AddTransient<IAuditLogService, MongoServices.AuditLogService>();
             services.AddTransient<IFlagDraftService, MongoServices.FlagDraftService>();
+            // Required by HeartbeatMessageHandler (live-set membership) and the C3b-2 commit
+            // coordinator (live-DC enumeration).
+            services.AddTransient<global::Application.ControlPlane.ILeaseStore, MongoServices.MongoLeaseStore>();
 
         }
 
@@ -45,6 +48,9 @@ public static class DbServiceCollectionExtensions
             services.AddTransient<IFeatureFlagService, EntityFrameworkCoreServices.FeatureFlagService>();
             services.AddTransient<IAuditLogService, EntityFrameworkCoreServices.AuditLogService>();
             services.AddTransient<IFlagDraftService, EntityFrameworkCoreServices.FlagDraftService>();
+            // Required by HeartbeatMessageHandler (live-set membership) and the C3b-2 commit
+            // coordinator (live-DC enumeration).
+            services.AddTransient<global::Application.ControlPlane.ILeaseStore, EntityFrameworkCoreServices.PostgresLeaseStore>();
 
         }
     }

--- a/modules/control-plane/src/Api/Setup/ServicesRegister.cs
+++ b/modules/control-plane/src/Api/Setup/ServicesRegister.cs
@@ -54,6 +54,10 @@ public static class ServicesRegister
             builder.Configuration.GetSection(PodHealthOptions.SectionName));
         builder.Services.AddHostedService<PodHealthChecker>();
 
+        // C3b-2 commit coordinator: gated-commit reconciliation of pending flag changes. No-ops
+        // unless ControlPlane:ConsistencyMode == GatedCommit (checked inside the worker).
+        builder.Services.AddHostedService<CommitCoordinatorWorker>();
+
         return builder;
     }
     

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/CommitCoordinatorWorkerTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/CommitCoordinatorWorkerTests.cs
@@ -1,0 +1,400 @@
+using Api.Application.ControlPlane;
+using Api.Infrastructure.Caches;
+using Application.Caches;
+using Application.ControlPlane;
+using Application.Services;
+using Domain.ControlPlane;
+using Domain.FeatureFlags;
+using Domain.Messages;
+using Infrastructure.Caches.Redis;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using StackExchange.Redis;
+
+namespace Api.IntegrationTests.ControlPlane;
+
+/// <summary>
+/// C3b-2 commit coordinator acceptance tests. Exercises the locked design end-to-end against real
+/// infrastructure: a real MongoDB (pending flags + DC leases) and a real Redis whose two logical DB
+/// indexes simulate two DCs' Redis (dc-a = db 0, dc-b = db 1). The coordinator commits a pending
+/// version only once EVERY live DC has it staged.
+///
+/// Requires:
+///  - MongoDB at mongodb://admin:password@localhost:27017 (unique throwaway DB, dropped on dispose).
+///  - Redis on port 6384 (override via C3B2_REDIS):
+///      docker run -d --rm -p 6384:6379 --name c3b2-redis redis:7-alpine
+/// Fails loudly (not silently skips) if either is unreachable.
+/// </summary>
+public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
+{
+    private const string MongoConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
+    private const string DefaultRedis = "localhost:6384";
+
+    private const string DcA = "dc-a";
+    private const string DcB = "dc-b";
+
+    private readonly string _dbName = $"featbit_c3b2_test_{Guid.NewGuid():N}";
+    private readonly Guid _envId = Guid.NewGuid();
+
+    private MongoDbClient _mongoDb = null!;
+    private FeatureFlagService _flagService = null!;
+    private MongoLeaseStore _leaseStore = null!;
+
+    private ConnectionMultiplexer _mux = null!;
+    private RedisCacheService _dcaCache = null!; // db 0
+    private RedisCacheService _dcbCache = null!; // db 1
+    private CompositeRedisCacheService _composite = null!;
+
+    private static string RedisConnectionString =>
+        Environment.GetEnvironmentVariable("C3B2_REDIS") ?? DefaultRedis;
+
+    public async Task InitializeAsync()
+    {
+        // ---- Mongo ----
+        var options = Options.Create(new MongoDbOptions
+        {
+            ConnectionString = MongoConnectionString,
+            Database = _dbName
+        });
+        _mongoDb = new MongoDbClient(options);
+        await _mongoDb.Database.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1));
+
+        _flagService = new FeatureFlagService(_mongoDb);
+        _leaseStore = new MongoLeaseStore(_mongoDb);
+
+        // ---- Redis (two DB indexes = two DCs) ----
+        var redisOptions = ConfigurationOptions.Parse(RedisConnectionString);
+        redisOptions.AbortOnConnectFail = false;
+        redisOptions.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(redisOptions);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{RedisConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6384:6379 --name c3b2-redis redis:7-alpine " +
+                "(or set the C3B2_REDIS env var).");
+        }
+
+        _dcaCache = new RedisCacheService(new TestRedisClient(_mux, db: 0));
+        _dcbCache = new RedisCacheService(new TestRedisClient(_mux, db: 1));
+
+        _composite = new CompositeRedisCacheService(
+            new[]
+            {
+                new DcCacheService(DcA, _dcaCache),
+                new DcCacheService(DcB, _dcbCache)
+            },
+            NullLogger<CompositeRedisCacheService>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        // flush both DC DB indexes so a shared Redis is left clean
+        await _mux.GetDatabase(0).ExecuteAsync("FLUSHDB");
+        await _mux.GetDatabase(1).ExecuteAsync("FLUSHDB");
+        _mux.Dispose();
+
+        await _mongoDb.Database.Client.DropDatabaseAsync(_dbName);
+    }
+
+    // ----- helpers -----
+
+    private FeatureFlag CreateFlag(string key, bool isEnabled)
+    {
+        var enabledVariationId = Guid.NewGuid().ToString();
+        var disabledVariationId = Guid.NewGuid().ToString();
+
+        var variations = new List<Variation>
+        {
+            new() { Id = enabledVariationId, Name = "true", Value = "true" },
+            new() { Id = disabledVariationId, Name = "false", Value = "false" }
+        };
+
+        return new FeatureFlag(
+            envId: _envId,
+            name: key,
+            description: string.Empty,
+            key: key,
+            isEnabled: isEnabled,
+            variationType: "boolean",
+            variations: variations,
+            disabledVariationId: disabledVariationId,
+            enabledVariationId: enabledVariationId,
+            tags: [],
+            currentUserId: Guid.NewGuid()
+        );
+    }
+
+    /// <summary>Seeds a committed flag (v1, disabled) with a staged pending change (v2, enabled).</summary>
+    private async Task<(FeatureFlag committed, FeatureFlag pendingValue, long pendingVersion)> SeedCommittedV1PendingV2(string key)
+    {
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _flagService.AddOneAsync(committed);
+
+        // the pending value is an edit of the SAME flag entity, so it carries the same Id (the
+        // staged Redis key and the coordinator's probe are both keyed on flag.Id)
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        pendingValue.Id = committed.Id;
+        const long pendingVersion = 2;
+        await _flagService.SetPendingAsync(_envId, key, pendingValue, pendingVersion);
+
+        return (committed, pendingValue, pendingVersion);
+    }
+
+    private async Task UpsertLeaseAsync(string dcId, DateTimeOffset expiresAt)
+    {
+        await _leaseStore.UpsertLeaseAsync(new DcLease
+        {
+            DcId = dcId,
+            Region = dcId,
+            LastHeartbeatAt = DateTimeOffset.UtcNow,
+            LeaseExpiresAt = expiresAt
+        });
+    }
+
+    private CommitCoordinatorWorker CreateSut(SpyMessageProducer producer)
+    {
+        // Wire IFeatureFlagService + ILeaseStore through a real DI scope, matching how the worker
+        // resolves them at runtime via IServiceScopeFactory.
+        var services = new ServiceCollection();
+        services.AddTransient<IFeatureFlagService>(_ => _flagService);
+        services.AddTransient<ILeaseStore>(_ => _leaseStore);
+        var provider = services.BuildServiceProvider();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ControlPlane:ConsistencyMode"] = "GatedCommit"
+            })
+            .Build();
+
+        return new CommitCoordinatorWorker(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            _composite,
+            producer,
+            configuration,
+            NullLogger<CommitCoordinatorWorker>.Instance);
+    }
+
+    // ----- acceptance cases -----
+
+    [Fact]
+    public async Task NoCommit_When_OnlyOneOfTwoLiveDcs_HasStaged()
+    {
+        const string key = "only-one-dc-staged";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        // both DCs are live
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        // only dc-a (db 0) has v2 staged
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer);
+
+        var committed = await sut.RunOnceAsync();
+
+        Assert.Equal(0, committed);
+        Assert.Empty(producer.Published);
+
+        // committed read still returns the OLD value; pending intact
+        var read = await _flagService.GetCommittedAsync(_envId, key);
+        Assert.False(read.IsEnabled);
+        Assert.Equal(1, read.CommittedVersion);
+
+        var raw = await _flagService.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(v, raw.Pending!.Version);
+
+        // dc-b committed pointer never advanced
+        Assert.False(await _dcbCache.HasStagedFlagAsync(flag.Id, v));
+    }
+
+    [Fact]
+    public async Task Commits_When_AllLiveDcs_HaveStaged()
+    {
+        const string key = "all-dcs-staged";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        // both DCs have v2 staged
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer);
+
+        var committed = await sut.RunOnceAsync();
+
+        Assert.Equal(1, committed);
+
+        // committed read now returns the NEW value + advanced version
+        var read = await _flagService.GetCommittedAsync(_envId, key);
+        Assert.True(read.IsEnabled);
+        Assert.Equal(v, read.CommittedVersion);
+
+        // pending slot cleared
+        var raw = await _flagService.GetAsync(_envId, key);
+        Assert.Null(raw.Pending);
+
+        // committed pointer advanced in BOTH DCs (broadcast)
+        var dcaPointer = await _mux.GetDatabase(0).StringGetAsync(RedisCaches.FlagCommittedPointer(flag.Id));
+        var dcbPointer = await _mux.GetDatabase(1).StringGetAsync(RedisCaches.FlagCommittedPointer(flag.Id));
+        Assert.Equal(v, (long)dcaPointer);
+        Assert.Equal(v, (long)dcbPointer);
+
+        // published to the evaluation-server topic with the new committed value
+        var publish = Assert.Single(producer.Published);
+        Assert.Equal(Topics.FeatureFlagChange, publish.Topic);
+        var publishedFlag = Assert.IsType<FeatureFlag>(publish.Message);
+        Assert.True(publishedFlag.IsEnabled);
+        Assert.Equal(flag.Id, publishedFlag.Id);
+    }
+
+    [Fact]
+    public async Task Commits_Ignoring_ExpiredDc_When_OnlyLiveDc_HasStaged()
+    {
+        const string key = "expired-dc-ignored";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));   // dc-a live
+        await UpsertLeaseAsync(DcB, now.AddMinutes(-5));  // dc-b lease EXPIRED
+
+        // only the live DC (dc-a) has v2 staged; dc-b never got it (but it's dead anyway)
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer);
+
+        var committed = await sut.RunOnceAsync();
+
+        Assert.Equal(1, committed);
+
+        var read = await _flagService.GetCommittedAsync(_envId, key);
+        Assert.True(read.IsEnabled);
+        Assert.Equal(v, read.CommittedVersion);
+
+        Assert.Single(producer.Published);
+    }
+
+    [Fact]
+    public async Task Skips_When_PendingVersion_NotNewerThanCommitted()
+    {
+        // committed v5, pending staged at v2 (stale) -> must be skipped on monotonicity (#34)
+        const string key = "stale-pending";
+        var committed = CreateFlag(key, isEnabled: true);
+        committed.CommittedVersion = 5;
+        await _flagService.AddOneAsync(committed);
+
+        var pendingValue = CreateFlag(key, isEnabled: false);
+        pendingValue.Id = committed.Id;
+        await _flagService.SetPendingAsync(_envId, key, pendingValue, version: 2);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        // even if both DCs have it staged, the stale version must not be committed
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, 2);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, 2);
+
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer);
+
+        var committed2 = await sut.RunOnceAsync();
+
+        Assert.Equal(0, committed2);
+        Assert.Empty(producer.Published);
+
+        var read = await _flagService.GetCommittedAsync(_envId, key);
+        Assert.True(read.IsEnabled);
+        Assert.Equal(5, read.CommittedVersion);
+    }
+
+    [Fact]
+    public async Task NoCommit_When_NoLiveDcs()
+    {
+        const string key = "no-live-dcs";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        // both DCs have it staged, but NO live leases exist
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer);
+
+        var committed = await sut.RunOnceAsync();
+
+        Assert.Equal(0, committed);
+        Assert.Empty(producer.Published);
+
+        var read = await _flagService.GetCommittedAsync(_envId, key);
+        Assert.False(read.IsEnabled);
+        Assert.Equal(1, read.CommittedVersion);
+    }
+
+    [Fact]
+    public async Task SecondTick_IsIdempotent_AfterCommit()
+    {
+        const string key = "idempotent";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer);
+
+        var first = await sut.RunOnceAsync();
+        var second = await sut.RunOnceAsync();
+
+        Assert.Equal(1, first);
+        Assert.Equal(0, second); // nothing left pending -> no-op
+        Assert.Single(producer.Published);
+    }
+
+    // ----- test doubles -----
+
+    private sealed class SpyMessageProducer : IMessageProducer
+    {
+        public List<(string Topic, object Message)> Published { get; } = new();
+
+        public Task PublishAsync<TMessage>(string topic, TMessage message) where TMessage : class
+        {
+            Published.Add((topic, message));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase(db);
+    }
+}


### PR DESCRIPTION
Closes #15. The commit coordinator that makes the gated invariant real: **no flag's new version is served until every live DC has it.**

**`CommitCoordinatorWorker`** (`BackgroundService`, GatedCommit only, interval `ControlPlane:CommitCoordinator:IntervalSeconds` default 5, `RunOnceAsync` for tests). Per tick: `GetPendingAsync()` → live DCs from leases → for each pending flag with `V > CommittedVersion`, if every live DC has `v{V}` staged (`GetStagedDcsAsync` probe) → `CommitFlagAsync` to all DCs + version-guarded `PromotePendingAsync` + publish `Topics.FeatureFlagChange`.

**Guards folded in:**
- **#34 monotonicity** — skip `V <= CommittedVersion`.
- **#33 lost-update** — `PromotePendingAsync(env,key,expectedVersion)` is now optimistic: Mongo via `Pending.Version`-filtered `ReplaceOneAsync`; EF via load+check+save (residual non-atomic window documented).

**Also:** registered `ILeaseStore` in control-plane DI — it was consumed by the A6 heartbeat handler but never registered, so lease upserts would have thrown at runtime (latent bug, masked by mocks in A6's unit tests).

Coordinator resolves the composite via the keyed `ICacheService` (cast to `CompositeRedisCacheService` for the probe, guarded); scoped services resolved per tick via `IServiceScopeFactory`. `// TODO: leader election` left for multi-replica control planes (follow-up).

**Verification (real Mongo + Redis):** coordinator 6/6 (one-DC=no-commit, all-DCs=commit+broadcast+publish, expired-DC ignored, stale-version skipped, no-live-DCs, idempotent re-tick); promote-guard 8/8 (incl. new version-mismatch no-op per provider); CP unit 50/50; CP integration 7/7; back-end unit 14/14; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)