### PR TITLE
✨ Eviction logging + metric in commit coordinator (C4)

### DIFF
--- a/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using Application.Caches;
 using Application.Configuration;
 using Application.ControlPlane;
@@ -39,6 +40,28 @@ public sealed class CommitCoordinatorWorker : BackgroundService
     /// <c>ControlPlane:CommitCoordinator:IntervalSeconds</c>.
     /// </summary>
     public static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Stable meter name for control-plane consistency observability. Operators / tests subscribe
+    /// to this meter (e.g. via <see cref="MeterListener"/> or <c>IMeterFactory</c>) to observe the
+    /// eviction counters emitted by the commit coordinator.
+    /// </summary>
+    public const string MeterName = "FeatBit.ControlPlane.Consistency";
+
+    /// <summary>
+    /// Counter incremented once per (flag-commit, evicted DC) pair: i.e. every time a flag version
+    /// is committed while a configured DC is absent from the live set (its lease expired / it is
+    /// down). Tagged with the evicted <c>dc_id</c>.
+    /// </summary>
+    public const string EvictedCommitCounterName = "control_plane.consistency.evicted_commits";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> EvictedCommitCounter = Meter.CreateCounter<long>(
+        EvictedCommitCounterName,
+        unit: "{commit}",
+        description:
+        "Number of flag-version commits made while a configured DC was evicted (absent from the live set).");
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICacheService _compositeCache;
@@ -195,6 +218,28 @@ public sealed class CommitCoordinatorWorker : BackgroundService
             // IS the new committed state; it carries the same shape the BestEffort path publishes.
             await _messageProducer.PublishAsync(Topics.FeatureFlagChange, pendingChange.Value);
             count++;
+
+            // Observability (#16): the commit decision above is intentionally made on the LIVE set
+            // (committing without a down DC is the design). Record — for operators — any CONFIGURED
+            // DC that was evicted (probed by GetStagedDcsAsync, so present in the staged map's key
+            // set, but absent from the live set). This does not change the commit decision.
+            var evictedDcs = stagedMap.Keys
+                .Where(dc => !liveDcs.Contains(dc))
+                .ToList();
+
+            if (evictedDcs.Count > 0)
+            {
+                foreach (var dc in evictedDcs)
+                {
+                    EvictedCommitCounter.Add(1, new KeyValuePair<string, object?>("dc_id", dc));
+                }
+
+                _logger.LogWarning(
+                    "Committed flag {FlagId} v{Version} without DC(s) {EvictedDcs} — proceeding on live set.",
+                    flag.Id,
+                    version,
+                    string.Join(", ", evictedDcs));
+            }
         }
 
         return count;

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/CommitCoordinatorWorkerTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/CommitCoordinatorWorkerTests.cs
@@ -9,8 +9,10 @@ using Domain.Messages;
 using Infrastructure.Caches.Redis;
 using Infrastructure.Persistence.MongoDb;
 using Infrastructure.Services.MongoDb;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -159,7 +161,9 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         });
     }
 
-    private CommitCoordinatorWorker CreateSut(SpyMessageProducer producer)
+    private CommitCoordinatorWorker CreateSut(
+        SpyMessageProducer producer,
+        ILogger<CommitCoordinatorWorker>? logger = null)
     {
         // Wire IFeatureFlagService + ILeaseStore through a real DI scope, matching how the worker
         // resolves them at runtime via IServiceScopeFactory.
@@ -180,7 +184,7 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
             _composite,
             producer,
             configuration,
-            NullLogger<CommitCoordinatorWorker>.Instance);
+            logger ?? NullLogger<CommitCoordinatorWorker>.Instance);
     }
 
     // ----- acceptance cases -----
@@ -378,7 +382,147 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         Assert.Single(producer.Published);
     }
 
+    // ----- eviction observability (#16) -----
+
+    [Fact]
+    public async Task EvictedCommit_Logs_And_IncrementsCounter_NamingEvictedDc()
+    {
+        // dc-a live + staged; dc-b is CONFIGURED (composite probes it) but its lease has EXPIRED, so
+        // it is evicted from the live set. The commit proceeds on the live set, and the eviction
+        // must be recorded (warning log naming dc-b + counter increment tagged dc_id=dc-b).
+        const string key = "evicted-commit-observed";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));   // dc-a live
+        await UpsertLeaseAsync(DcB, now.AddMinutes(-5));  // dc-b lease EXPIRED -> evicted
+
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var logger = new CapturingLogger();
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer, logger);
+
+        using var counter = new CounterCollector(CommitCoordinatorWorker.EvictedCommitCounterName);
+
+        var committed = await sut.RunOnceAsync();
+
+        // commit decision unchanged: it still committed on the live set
+        Assert.Equal(1, committed);
+
+        // metric: exactly one increment, tagged with the evicted dc_id
+        var measurement = Assert.Single(counter.Measurements);
+        Assert.Equal(1, measurement.Value);
+        Assert.Equal(DcB, measurement.Tags["dc_id"]);
+
+        // log: a warning naming the flag, the version, and the evicted DC
+        var warning = Assert.Single(logger.Warnings);
+        Assert.Contains(flag.Id.ToString(), warning);
+        Assert.Contains(v.ToString(), warning);
+        Assert.Contains(DcB, warning);
+    }
+
+    [Fact]
+    public async Task NoEviction_When_AllConfiguredDcsLive_DoesNotLogOrIncrement()
+    {
+        // both configured DCs are live + staged -> no eviction; no extra warning, no counter.
+        const string key = "no-eviction-observed";
+        var (_, _, v) = await SeedCommittedV1PendingV2(key);
+        var flag = await _flagService.GetAsync(_envId, key);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+
+        var logger = new CapturingLogger();
+        var producer = new SpyMessageProducer();
+        var sut = CreateSut(producer, logger);
+
+        using var counter = new CounterCollector(CommitCoordinatorWorker.EvictedCommitCounterName);
+
+        var committed = await sut.RunOnceAsync();
+
+        Assert.Equal(1, committed);
+        Assert.Empty(counter.Measurements);
+        Assert.Empty(logger.Warnings);
+    }
+
     // ----- test doubles -----
+
+    /// <summary>
+    /// Captures emitted measurements for a single named counter on the control-plane consistency
+    /// meter via <see cref="MeterListener"/>, so the test can assert the eviction counter fired
+    /// with the expected value + tags.
+    /// </summary>
+    private sealed class CounterCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+
+        public List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Measurements { get; } = new();
+
+        public CounterCollector(string instrumentName)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == CommitCoordinatorWorker.MeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+            {
+                var dict = new Dictionary<string, object?>();
+                foreach (var tag in tags)
+                {
+                    dict[tag.Key] = tag.Value;
+                }
+
+                Measurements.Add((measurement, dict));
+            });
+
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    /// <summary>Captures warning-level log messages (rendered) for assertion.</summary>
+    private sealed class CapturingLogger : ILogger<CommitCoordinatorWorker>
+    {
+        public List<string> Warnings { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
 
     private sealed class SpyMessageProducer : IMessageProducer
     {


### PR DESCRIPTION
Closes #16. Observability for the case where the coordinator commits a flag while a **configured** DC is **absent from the live set** (evicted/down).

`evictedDcs = GetStagedDcsAsync().Keys (configured) − liveDcs (leased)`. On a commit with non-empty `evictedDcs`: a structured **warning** naming flag/version/evicted DcIds, and a **`System.Diagnostics.Metrics`** counter `control_plane.consistency.evicted_commits` (Meter `FeatBit.ControlPlane.Consistency`, tagged `dc_id`). Names exposed as public consts. Commit-on-live-set decision unchanged — observability only.

**Verification (real Redis + Mongo):** coordinator 8/8 (6 prior + 2 new: eviction logs+counts tagged dc-b via MeterListener; all-live emits nothing). TDD red-checked. CP unit 50/50, integration 9/9, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)