### PR TITLE
✨ Returning-DC recovery backfill (E1)

### DIFF
--- a/modules/back-end/src/Application/Services/IFeatureFlagService.cs
+++ b/modules/back-end/src/Application/Services/IFeatureFlagService.cs
@@ -52,4 +52,12 @@ public interface IFeatureFlagService : IService<FeatureFlag>
     /// coordinator to discover the set of pending changes it must reconcile.
     /// </summary>
     Task<IReadOnlyList<FeatureFlag>> GetPendingAsync();
+
+    /// <summary>
+    /// Enumerate the COMMITTED value of every flag (across all envs). Each returned flag has its
+    /// <c>Pending</c> slot cleared (mirroring <see cref="GetCommittedAsync"/>) so callers never see
+    /// staged data. Used by the returning-DC recovery worker to backfill a DC's Redis with the
+    /// authoritative committed state of all flags.
+    /// </summary>
+    Task<IReadOnlyList<FeatureFlag>> GetAllCommittedAsync();
 }

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
@@ -188,4 +188,21 @@ public class FeatureFlagService(AppDbContext dbContext)
             .Where(f => f.Pending != null)
             .ToListAsync();
     }
+
+    public async Task<IReadOnlyList<FeatureFlag>> GetAllCommittedAsync()
+    {
+        // enumerate every flag (across all envs), mirroring how RedisPopulatingService loads all
+        // flags, then strip the pending slot so only the COMMITTED value is exposed (mirroring
+        // GetCommittedAsync). AsNoTracking so the strip is purely read-shaping and never persisted.
+        var flags = await Queryable
+            .AsNoTracking()
+            .ToListAsync();
+
+        foreach (var flag in flags)
+        {
+            flag.Pending = null;
+        }
+
+        return flags;
+    }
 }

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
@@ -208,4 +208,18 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
         var flags = await FindManyAsync(x => x.Pending != null);
         return flags.ToList();
     }
+
+    public async Task<IReadOnlyList<FeatureFlag>> GetAllCommittedAsync()
+    {
+        // enumerate every flag (across all envs), mirroring how RedisPopulatingService loads all
+        // flags, then strip the pending slot so only the COMMITTED value is exposed (mirroring
+        // GetCommittedAsync). The top-level document is the committed value.
+        var flags = await FindManyAsync(_ => true);
+        foreach (var flag in flags)
+        {
+            flag.Pending = null;
+        }
+
+        return flags.ToList();
+    }
 }

--- a/modules/control-plane/src/Api/Application/ControlPlane/RecoveryWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/RecoveryWorker.cs
@@ -1,0 +1,188 @@
+using Application.Caches;
+using Application.Configuration;
+using Application.ControlPlane;
+using Application.Services;
+using Api.Infrastructure.Caches;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Application.ControlPlane;
+
+/// <summary>
+/// E1 returning-DC recovery (catch-up-before-serve). Under <see cref="ConsistencyMode.GatedCommit"/>
+/// the commit coordinator commits a flag on the LIVE set, so a flag that changed while a DC was
+/// evicted is committed with NO pending — the returned DC's Redis would otherwise stay stale
+/// forever. This worker watches the live set; when a DC newly appears (its lease returns), it
+/// backfills that DC's Redis with the COMMITTED value of every flag (stage the versioned value +
+/// flip the committed pointer + advance the index), so the returned DC catches up.
+///
+/// Model A, locked decisions:
+///  - A: a separate worker (this one), not folded into the commit coordinator.
+///  - B: per-DC TARGETED writes (<see cref="CompositeRedisCacheService.StageFlagToDcAsync"/> /
+///       <see cref="CompositeRedisCacheService.CommitFlagToDcAsync"/>) — only the returned DC is
+///       written, never a broadcast.
+///  - C: no readiness gate — backfill runs as soon as the DC is seen live.
+///  - D: best-effort client refresh — no per-DC client-targeting primitive exists today, so this is
+///       logged as a TODO rather than pushed to ALL DCs (which would defeat the per-DC intent).
+///
+/// Idempotent: re-staging/re-committing an already-present version is a no-op (the staged value key
+/// and committed pointer are version-keyed). It does NOT publish <c>Topics.FeatureFlagChange</c> —
+/// the committed value did not change globally, only one DC's Redis is being repaired.
+///
+/// TODO: leader election if control plane runs multiple replicas. Today multiple replicas would each
+/// run this loop; the staged-write + commit-pointer flip are idempotent so it is safe (at worst
+/// redundant writes), but a leader election would avoid the duplicate work. Out of scope here.
+/// </summary>
+public sealed class RecoveryWorker : BackgroundService
+{
+    /// <summary>
+    /// Default interval between recovery ticks when not overridden via
+    /// <c>ControlPlane:Recovery:IntervalSeconds</c>.
+    /// </summary>
+    public static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(10);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ICacheService _compositeCache;
+    private readonly bool _enabled;
+    private readonly TimeSpan _interval;
+    private readonly ILogger<RecoveryWorker> _logger;
+
+    // DcIds seen live on the previous tick. A DcId present now but absent here is "newly present"
+    // (returned / first-seen) and gets backfilled. First-seen counts as returned, which is harmless
+    // (the DC is current after the backfill regardless).
+    private HashSet<string> _previousLiveSet = new();
+
+    public RecoveryWorker(
+        IServiceScopeFactory scopeFactory,
+        [FromKeyedServices("compositeCache")] ICacheService compositeCache,
+        IConfiguration configuration,
+        ILogger<RecoveryWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _compositeCache = compositeCache;
+        _logger = logger;
+        _enabled = configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit;
+
+        var seconds = configuration.GetValue<int?>("ControlPlane:Recovery:IntervalSeconds");
+        _interval = seconds is > 0
+            ? TimeSpan.FromSeconds(seconds.Value)
+            : DefaultInterval;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_enabled)
+        {
+            _logger.LogInformation(
+                "Recovery worker disabled (consistency mode is not GatedCommit).");
+            return;
+        }
+
+        using var timer = new PeriodicTimer(_interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                var backfilled = await RunOnceAsync(stoppingToken);
+                if (backfilled > 0)
+                {
+                    _logger.LogInformation(
+                        "Recovery worker backfilled {BackfilledCount} returning DC(s).",
+                        backfilled);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // ignore cancellation from the timer loop itself
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while running the recovery worker tick.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs a single recovery tick and returns the number of DCs backfilled. Exposed so it can
+    /// be invoked directly (e.g. by integration tests) without waiting on the periodic timer.
+    ///
+    /// For each DcId newly present in the live set since the previous tick, every flag's committed
+    /// value is staged and committed into that DC's Redis (targeted, not broadcast).
+    /// </summary>
+    public async Task<int> RunOnceAsync(CancellationToken cancellationToken = default)
+    {
+        // ILeaseStore / IFeatureFlagService are scoped (per-request) in DI; resolve them inside a
+        // scope so the singleton BackgroundService does not capture a scoped/disposed instance.
+        using var scope = _scopeFactory.CreateScope();
+        var featureFlagService = scope.ServiceProvider.GetRequiredService<IFeatureFlagService>();
+        var leaseStore = scope.ServiceProvider.GetRequiredService<ILeaseStore>();
+
+        // Live DCs = distinct DcIds that currently hold at least one unexpired lease.
+        var liveSet = await leaseStore.GetLiveSetAsync(DateTimeOffset.UtcNow);
+        var liveDcs = liveSet
+            .Select(lease => lease.DcId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct()
+            .ToHashSet();
+
+        // Newly-present DcIds = live now but not on the previous tick.
+        var returned = liveDcs.Where(dc => !_previousLiveSet.Contains(dc)).ToList();
+
+        // Advance the watermark for the next tick regardless of what we do below.
+        _previousLiveSet = liveDcs;
+
+        if (returned.Count == 0)
+        {
+            return 0;
+        }
+
+        // StageFlagToDcAsync / CommitFlagToDcAsync are coordinator-only targeted writes that live on
+        // CompositeRedisCacheService, not on the ICacheService contract. In the Redis path the keyed
+        // "compositeCache" service is always a CompositeRedisCacheService; guard the cast so a
+        // misconfiguration (e.g. None cache) degrades to a clear log instead of a crash loop.
+        if (_compositeCache is not CompositeRedisCacheService composite)
+        {
+            _logger.LogWarning(
+                "Recovery worker requires the composite Redis cache (got {CacheType}); skipping tick.",
+                _compositeCache.GetType().FullName);
+            return 0;
+        }
+
+        var allCommitted = await featureFlagService.GetAllCommittedAsync();
+
+        var backfilled = 0;
+        foreach (var dcId in returned)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var flag in allCommitted)
+            {
+                // The committed value's version token, mirroring how FeatureFlagChangeMessageHandler
+                // derives the staged version from the flag's UpdatedAt.
+                var ts = new DateTimeOffset(flag.UpdatedAt).ToUnixTimeMilliseconds();
+
+                // Stage the versioned value, then flip the committed pointer + index — both targeted
+                // at ONLY the returned DC. Idempotent: re-applying an already-present version no-ops.
+                await composite.StageFlagToDcAsync(dcId, flag, ts);
+                await composite.CommitFlagToDcAsync(dcId, flag.EnvId, flag.Id.ToString(), ts);
+            }
+
+            // D (best-effort client refresh): there is no per-DC client-targeting primitive today, so
+            // pushing a full sync to that DC's connected clients is deferred rather than broadcast to
+            // ALL DCs (which would defeat the per-DC intent).
+            // TODO per-DC client refresh: trigger PushFullSync for dcId's connected clients once a
+            // per-DC client-targeting primitive exists.
+            _logger.LogInformation(
+                "Recovery: backfilled returning DC {DcId} with {FlagCount} committed flag(s). " +
+                "TODO per-DC client refresh deferred (no per-DC client targeting yet).",
+                dcId,
+                allCommitted.Count);
+
+            backfilled++;
+        }
+
+        return backfilled;
+    }
+}

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -157,6 +157,41 @@ public class CompositeRedisCacheService(
         return results;
     }
 
+    /// <summary>
+    /// Recovery-facing targeted write (E1): stages <paramref name="flag"/> at version
+    /// <paramref name="ts"/> into ONE DC's Redis (the <see cref="DcCacheService"/> whose
+    /// <see cref="DcCacheService.DcId"/> matches <paramref name="dcId"/>), unlike the broadcast
+    /// <see cref="StageFlagAsync"/>. If no DC matches, logs a warning and no-ops. A failing write is
+    /// swallowed and logged with the same resilience as <see cref="BroadcastAsync"/>.
+    /// </summary>
+    public Task StageFlagToDcAsync(string dcId, FeatureFlag flag, long ts) =>
+        TargetedAsync(dcId, s => s.StageFlagAsync(flag, ts), nameof(StageFlagToDcAsync));
+
+    /// <summary>
+    /// Recovery-facing targeted write (E1): commits <paramref name="flagId"/> at version
+    /// <paramref name="ts"/> into ONE DC's Redis (advancing that DC's committed pointer + index),
+    /// unlike the broadcast <see cref="CommitFlagAsync"/>. If no DC matches <paramref name="dcId"/>,
+    /// logs a warning and no-ops. A failing write is swallowed and logged with the same resilience
+    /// as <see cref="BroadcastAsync"/>.
+    /// </summary>
+    public Task CommitFlagToDcAsync(string dcId, Guid envId, string flagId, long ts) =>
+        TargetedAsync(dcId, s => s.CommitFlagAsync(envId, flagId, ts), nameof(CommitFlagToDcAsync));
+
+    private async Task TargetedAsync(string dcId, Func<ICacheService, Task> action, string operationName)
+    {
+        var dc = cacheServices.FirstOrDefault(c => c.DcId == dcId);
+        if (dc == null)
+        {
+            logger.LogWarning(
+                "Targeted cache operation '{Operation}' requested for unknown DC {DcId}; no matching cache instance. No-op.",
+                operationName,
+                dcId);
+            return;
+        }
+
+        await ExecuteSafelyAsync(dc, action, operationName);
+    }
+
     private async Task<bool> ProbeStagedSafelyAsync(DcCacheService dc, Guid id, long ts)
     {
         try

--- a/modules/control-plane/src/Api/Setup/ServicesRegister.cs
+++ b/modules/control-plane/src/Api/Setup/ServicesRegister.cs
@@ -58,6 +58,10 @@ public static class ServicesRegister
         // unless ControlPlane:ConsistencyMode == GatedCommit (checked inside the worker).
         builder.Services.AddHostedService<CommitCoordinatorWorker>();
 
+        // E1 returning-DC recovery: backfills a DC's Redis with all committed flag values when its
+        // lease returns to the live set. No-ops unless ControlPlane:ConsistencyMode == GatedCommit.
+        builder.Services.AddHostedService<RecoveryWorker>();
+
         return builder;
     }
     

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/RecoveryWorkerTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/RecoveryWorkerTests.cs
@@ -1,0 +1,294 @@
+using Api.Application.ControlPlane;
+using Api.Infrastructure.Caches;
+using Application.Caches;
+using Application.ControlPlane;
+using Application.Services;
+using Domain.ControlPlane;
+using Domain.FeatureFlags;
+using Infrastructure.Caches.Redis;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using StackExchange.Redis;
+
+namespace Api.IntegrationTests.ControlPlane;
+
+/// <summary>
+/// E1 returning-DC recovery acceptance tests. Exercises the locked Model A design end-to-end against
+/// real infrastructure: a real MongoDB (committed flags + DC leases) and a real Redis whose two
+/// logical DB indexes simulate two DCs' Redis (dc-a = db 0, dc-b = db 1).
+///
+/// Scenario: both DCs committed v1; dc-b loses its lease; the flag is committed to v2 on dc-a only
+/// (dc-b absent); dc-b's lease returns -> a recovery tick backfills dc-b's Redis so it reaches v2
+/// (versioned value key + committed pointer + index all at v2). A DC already current is a no-op.
+///
+/// Requires:
+///  - MongoDB at mongodb://admin:password@localhost:27017 (unique throwaway DB, dropped on dispose).
+///  - Redis on port 6387 (override via E1_REDIS):
+///      docker run -d --rm -p 6387:6379 --name cp-e1-recovery-redis redis:7-alpine
+/// Fails loudly (not silently skips) if either is unreachable.
+/// </summary>
+public sealed class RecoveryWorkerTests : IAsyncLifetime
+{
+    private const string MongoConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
+    private const string DefaultRedis = "localhost:6387";
+
+    private const string DcA = "dc-a";
+    private const string DcB = "dc-b";
+
+    private readonly string _dbName = $"featbit_e1_test_{Guid.NewGuid():N}";
+    private readonly Guid _envId = Guid.NewGuid();
+
+    private MongoDbClient _mongoDb = null!;
+    private FeatureFlagService _flagService = null!;
+    private MongoLeaseStore _leaseStore = null!;
+
+    private ConnectionMultiplexer _mux = null!;
+    private RedisCacheService _dcaCache = null!; // db 0
+    private RedisCacheService _dcbCache = null!; // db 1
+    private CompositeRedisCacheService _composite = null!;
+
+    private static string RedisConnectionString =>
+        Environment.GetEnvironmentVariable("E1_REDIS") ?? DefaultRedis;
+
+    public async Task InitializeAsync()
+    {
+        // ---- Mongo ----
+        var options = Options.Create(new MongoDbOptions
+        {
+            ConnectionString = MongoConnectionString,
+            Database = _dbName
+        });
+        _mongoDb = new MongoDbClient(options);
+        await _mongoDb.Database.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1));
+
+        _flagService = new FeatureFlagService(_mongoDb);
+        _leaseStore = new MongoLeaseStore(_mongoDb);
+
+        // ---- Redis (two DB indexes = two DCs) ----
+        var redisOptions = ConfigurationOptions.Parse(RedisConnectionString);
+        redisOptions.AbortOnConnectFail = false;
+        redisOptions.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(redisOptions);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{RedisConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6387:6379 --name cp-e1-recovery-redis redis:7-alpine " +
+                "(or set the E1_REDIS env var).");
+        }
+
+        _dcaCache = new RedisCacheService(new TestRedisClient(_mux, db: 0));
+        _dcbCache = new RedisCacheService(new TestRedisClient(_mux, db: 1));
+
+        _composite = new CompositeRedisCacheService(
+            new[]
+            {
+                new DcCacheService(DcA, _dcaCache),
+                new DcCacheService(DcB, _dcbCache)
+            },
+            NullLogger<CompositeRedisCacheService>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        // flush both DC DB indexes so a shared Redis is left clean
+        await _mux.GetDatabase(0).ExecuteAsync("FLUSHDB");
+        await _mux.GetDatabase(1).ExecuteAsync("FLUSHDB");
+        _mux.Dispose();
+
+        await _mongoDb.Database.Client.DropDatabaseAsync(_dbName);
+    }
+
+    // ----- helpers -----
+
+    private FeatureFlag CreateFlag(string key, bool isEnabled)
+    {
+        var enabledVariationId = Guid.NewGuid().ToString();
+        var disabledVariationId = Guid.NewGuid().ToString();
+
+        var variations = new List<Variation>
+        {
+            new() { Id = enabledVariationId, Name = "true", Value = "true" },
+            new() { Id = disabledVariationId, Name = "false", Value = "false" }
+        };
+
+        return new FeatureFlag(
+            envId: _envId,
+            name: key,
+            description: string.Empty,
+            key: key,
+            isEnabled: isEnabled,
+            variationType: "boolean",
+            variations: variations,
+            disabledVariationId: disabledVariationId,
+            enabledVariationId: enabledVariationId,
+            tags: [],
+            currentUserId: Guid.NewGuid()
+        );
+    }
+
+    private async Task UpsertLeaseAsync(string dcId, DateTimeOffset expiresAt)
+    {
+        await _leaseStore.UpsertLeaseAsync(new DcLease
+        {
+            DcId = dcId,
+            Region = dcId,
+            LastHeartbeatAt = DateTimeOffset.UtcNow,
+            LeaseExpiresAt = expiresAt
+        });
+    }
+
+    private RecoveryWorker CreateSut(ILogger<RecoveryWorker>? logger = null)
+    {
+        // Wire IFeatureFlagService + ILeaseStore through a real DI scope, matching how the worker
+        // resolves them at runtime via IServiceScopeFactory.
+        var services = new ServiceCollection();
+        services.AddTransient<IFeatureFlagService>(_ => _flagService);
+        services.AddTransient<ILeaseStore>(_ => _leaseStore);
+        var provider = services.BuildServiceProvider();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ControlPlane:ConsistencyMode"] = "GatedCommit"
+            })
+            .Build();
+
+        return new RecoveryWorker(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            _composite,
+            configuration,
+            logger ?? NullLogger<RecoveryWorker>.Instance);
+    }
+
+    /// <summary>
+    /// The committed version token the worker derives for a flag (mirrors
+    /// FeatureFlagChangeMessageHandler / RecoveryWorker: unix-ms of UpdatedAt).
+    /// </summary>
+    private static long VersionTokenOf(FeatureFlag flag) =>
+        new DateTimeOffset(flag.UpdatedAt).ToUnixTimeMilliseconds();
+
+    // ----- acceptance -----
+
+    [Fact]
+    public async Task Backfills_ReturningDc_To_LatestCommittedVersion()
+    {
+        const string key = "returning-dc";
+
+        // ---- v1 committed on BOTH DCs (both live) ----
+        var v1 = CreateFlag(key, isEnabled: false);
+        v1.CommittedVersion = 1;
+        await _flagService.AddOneAsync(v1);
+        var v1Ts = VersionTokenOf(v1);
+
+        await _dcaCache.StageFlagAsync(v1, v1Ts);
+        await _dcaCache.CommitFlagAsync(_envId, v1.Id.ToString(), v1Ts);
+        await _dcbCache.StageFlagAsync(v1, v1Ts);
+        await _dcbCache.CommitFlagAsync(_envId, v1.Id.ToString(), v1Ts);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var sut = CreateSut();
+
+        // First tick: both DCs first-seen -> backfilled (harmless), establishes the watermark.
+        await sut.RunOnceAsync();
+
+        // ---- dc-b loses its lease ----
+        await UpsertLeaseAsync(DcB, now.AddMinutes(-5)); // expired
+
+        // ---- flag changes to v2, committed on dc-a ONLY (dc-b absent) ----
+        // The committed top-level value advances to v2 with NO pending (mirrors the coordinator
+        // committing on the live set while dc-b is evicted).
+        var v2 = CreateFlag(key, isEnabled: true);
+        v2.Id = v1.Id;
+        v2.CommittedVersion = 2;
+        // ensure a distinct, newer version token than v1
+        v2.UpdatedAt = v1.UpdatedAt.AddSeconds(1);
+        await _flagService.UpdateAsync(v2);
+        var v2Ts = VersionTokenOf(v2);
+        Assert.NotEqual(v1Ts, v2Ts);
+
+        await _dcaCache.StageFlagAsync(v2, v2Ts);
+        await _dcaCache.CommitFlagAsync(_envId, v2.Id.ToString(), v2Ts);
+
+        // dc-b is still at v1 and never got v2.
+        Assert.False(await _dcbCache.HasStagedFlagAsync(v2.Id, v2Ts));
+        var dcbPointerBefore = await _mux.GetDatabase(1).StringGetAsync(RedisCaches.FlagCommittedPointer(v2.Id));
+        Assert.Equal(v1Ts, (long)dcbPointerBefore);
+
+        // A recovery tick now sees only dc-a live; nothing returned.
+        var noReturn = await sut.RunOnceAsync();
+        Assert.Equal(0, noReturn);
+
+        // ---- dc-b's lease returns ----
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var backfilled = await sut.RunOnceAsync();
+
+        // exactly one DC (dc-b) backfilled
+        Assert.Equal(1, backfilled);
+
+        // dc-b's Redis now has v2: versioned value key + committed pointer + index all at v2.
+        Assert.True(await _dcbCache.HasStagedFlagAsync(v2.Id, v2Ts));
+
+        var dcbPointerAfter = await _mux.GetDatabase(1).StringGetAsync(RedisCaches.FlagCommittedPointer(v2.Id));
+        Assert.Equal(v2Ts, (long)dcbPointerAfter);
+
+        var dcbIndexScore = await _mux.GetDatabase(1)
+            .SortedSetScoreAsync(RedisKeys.FlagIndex(_envId), v2.Id.ToString());
+        Assert.NotNull(dcbIndexScore);
+        Assert.Equal(v2Ts, (long)dcbIndexScore!.Value);
+
+        // dc-a was untouched by the recovery (it was already live, not returning).
+        var dcaPointer = await _mux.GetDatabase(0).StringGetAsync(RedisCaches.FlagCommittedPointer(v2.Id));
+        Assert.Equal(v2Ts, (long)dcaPointer);
+    }
+
+    [Fact]
+    public async Task NoOp_When_NoDcReturned()
+    {
+        const string key = "steady-state";
+
+        var v1 = CreateFlag(key, isEnabled: true);
+        v1.CommittedVersion = 1;
+        await _flagService.AddOneAsync(v1);
+        var v1Ts = VersionTokenOf(v1);
+
+        await _dcaCache.StageFlagAsync(v1, v1Ts);
+        await _dcaCache.CommitFlagAsync(_envId, v1.Id.ToString(), v1Ts);
+        await _dcbCache.StageFlagAsync(v1, v1Ts);
+        await _dcbCache.CommitFlagAsync(_envId, v1.Id.ToString(), v1Ts);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var sut = CreateSut();
+
+        // First tick establishes the watermark (both first-seen -> backfilled once).
+        var first = await sut.RunOnceAsync();
+        Assert.Equal(2, first);
+
+        // Second tick with the SAME live set: nothing returned -> no-op.
+        var second = await sut.RunOnceAsync();
+        Assert.Equal(0, second);
+    }
+
+    // ----- test doubles -----
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase(db);
+    }
+}


### PR DESCRIPTION
Closes #23. Fixes the traced gap: after a DC is evicted and the coordinator commits + clears pending, a flag changed during the outage is committed with no pending, so the returned DC's Redis would stay stale forever.

**`RecoveryWorker`** (BackgroundService, GatedCommit only, interval `ControlPlane:Recovery:IntervalSeconds` default 10, `RunOnceAsync` for tests): tracks the live DC set across ticks; for each DcId newly present, backfills it with every flag's current committed value via new **per-DC targeted** `StageFlagToDcAsync`/`CommitFlagToDcAsync` on the composite (decision B) — only that DC's Redis is touched. New `IFeatureFlagService.GetAllCommittedAsync()` (Mongo + EF, pending stripped). No global publish; idempotent.

Decisions: separate worker (A), per-DC targeted write (B), serve-through/no readiness gate (C). **Per-DC connected-client refresh (D) deferred** — no per-DC client-targeting primitive exists; logged TODO, follow-up to be filed. (Reconnecting/new clients read the backfilled Redis via D2.)

**Verification (real Mongo + Redis :6387):** recovery 2/2 (dc-b backfilled to v2 after return: versioned value + pointer + index; no-op when nothing returned); CP integration 11/11; CP unit 50/50; back-end neighbor 4/4; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)