### PR TITLE
✨ Segment committed/pending model (S1, part of C5)

### DIFF
--- a/infra/postgresql/docker-entrypoint-initdb.d/v5.5.2.sql
+++ b/infra/postgresql/docker-entrypoint-initdb.d/v5.5.2.sql
@@ -1,0 +1,8 @@
+\connect featbit
+
+-- S1: committed-vs-pending for segments (Postgres parity with the Mongo path).
+-- committed_version: monotonic version of the last COMMITTED change (default 0).
+-- pending: a staged-but-not-committed change, stored as jsonb (NULL when none).
+ALTER TABLE segments
+    ADD COLUMN committed_version bigint NOT NULL DEFAULT 0,
+    ADD COLUMN pending jsonb NULL;

--- a/modules/back-end/src/Application/Services/ISegmentService.cs
+++ b/modules/back-end/src/Application/Services/ISegmentService.cs
@@ -19,4 +19,47 @@ public interface ISegmentService : IService<Segment>
     Task<ICollection<string>> GetAllTagsAsync(Guid envId);
 
     Task<ICollection<SegmentCache>> GetCachesAsync();
+
+    /// <summary>
+    /// Authoritative read: returns the COMMITTED segment value, never a pending
+    /// (staged-but-not-committed) change. The returned segment has its <c>Pending</c>
+    /// slot cleared so callers cannot accidentally serve staged data. Keyed by segment
+    /// <paramref name="id"/> since a segment is a single entity (possibly shared across envs).
+    /// </summary>
+    Task<Segment> GetCommittedAsync(Guid id);
+
+    /// <summary>
+    /// Stage <paramref name="pendingValue"/> as a pending change on the segment identified by
+    /// <paramref name="id"/>. The committed value is left untouched, so
+    /// <see cref="GetCommittedAsync"/> still returns the old value.
+    /// </summary>
+    Task SetPendingAsync(Guid id, Segment pendingValue, long version);
+
+    /// <summary>
+    /// Optimistically promote the staged pending change to committed for the segment identified by
+    /// <paramref name="id"/>, so <see cref="GetCommittedAsync"/> returns the new value. The
+    /// promotion happens ONLY if the stored <see cref="PendingSegmentChange.Version"/> still equals
+    /// <paramref name="expectedVersion"/>; otherwise it is a no-op. This version guard prevents a
+    /// lost update when a racing <see cref="SetPendingAsync"/> replaces the pending change between
+    /// the coordinator reading it and committing it (#33), and lets the coordinator skip stale
+    /// promotions (#34).
+    /// </summary>
+    /// <returns><c>true</c> if the pending change was promoted; <c>false</c> if there was no
+    /// pending change or its version no longer matched <paramref name="expectedVersion"/>.</returns>
+    Task<bool> PromotePendingAsync(Guid id, long expectedVersion);
+
+    /// <summary>
+    /// Enumerate every segment that currently has a staged-but-not-committed change, i.e.
+    /// <see cref="Segment.Pending"/> is not null. Used by the commit coordinator to discover
+    /// the set of pending changes it must reconcile.
+    /// </summary>
+    Task<IReadOnlyList<Segment>> GetPendingAsync();
+
+    /// <summary>
+    /// Enumerate the COMMITTED value of every segment. Each returned segment has its <c>Pending</c>
+    /// slot cleared (mirroring <see cref="GetCommittedAsync"/>) so callers never see staged data.
+    /// Used by the returning-DC recovery worker to backfill a DC's Redis with the authoritative
+    /// committed state of all segments.
+    /// </summary>
+    Task<IReadOnlyList<Segment>> GetAllCommittedAsync();
 }

--- a/modules/back-end/src/Domain/Segments/PendingSegmentChange.cs
+++ b/modules/back-end/src/Domain/Segments/PendingSegmentChange.cs
@@ -1,0 +1,19 @@
+namespace Domain.Segments;
+
+/// <summary>
+/// A staged-but-not-committed change to a <see cref="Segment"/>. Held alongside the
+/// committed value so the authoritative (committed) read can ignore it until promotion.
+/// </summary>
+public class PendingSegmentChange
+{
+    /// <summary>
+    /// Monotonic version this pending change will carry once it is promoted to committed.
+    /// </summary>
+    public long Version { get; set; }
+
+    /// <summary>
+    /// The staged segment value. This is NOT the authoritative value and must not be served
+    /// until <see cref="Segment.PromotePending"/> makes it committed.
+    /// </summary>
+    public Segment Value { get; set; }
+}

--- a/modules/back-end/src/Domain/Segments/Segment.cs
+++ b/modules/back-end/src/Domain/Segments/Segment.cs
@@ -34,7 +34,24 @@ public class Segment : AuditedEntity
 
     public bool IsArchived { get; set; }
 
+    /// <summary>
+    /// Monotonic version of the last COMMITTED change to this segment. The committed
+    /// value is the authoritative value that may be safely served to evaluators.
+    /// </summary>
+    public long CommittedVersion { get; set; }
+
+    /// <summary>
+    /// A staged-but-not-committed change. Null when there is no pending change
+    /// (the default). When set, the committed read must continue to return the
+    /// committed value and ignore this pending change until it is promoted.
+    /// </summary>
+    public PendingSegmentChange Pending { get; set; }
+
     public bool IsEnvironmentSpecific => Type == SegmentType.EnvironmentSpecific;
+
+    public Segment()
+    {
+    }
 
     public Segment(
         Guid workspaceId,
@@ -162,5 +179,50 @@ public class Segment : AuditedEntity
         json.Remove("isEnvironmentSpecific");
 
         return json;
+    }
+
+    /// <summary>
+    /// Stage <paramref name="pendingValue"/> as a pending (not-yet-committed) change.
+    /// The committed value is left untouched, so a committed read still returns the
+    /// old value until <see cref="PromotePending"/> is called.
+    /// </summary>
+    public void SetPending(Segment pendingValue, long version)
+    {
+        Pending = new PendingSegmentChange
+        {
+            Version = version,
+            Value = pendingValue
+        };
+    }
+
+    /// <summary>
+    /// Promote the staged pending change to committed: the pending value becomes the
+    /// committed value, <see cref="CommittedVersion"/> advances to the pending version,
+    /// and the pending slot is cleared. No-op when there is no pending change.
+    /// </summary>
+    public void PromotePending()
+    {
+        if (Pending == null)
+        {
+            return;
+        }
+
+        var promoted = Pending.Value;
+        var version = Pending.Version;
+
+        // adopt the committed-relevant fields from the pending value
+        Name = promoted.Name;
+        Key = promoted.Key;
+        Type = promoted.Type;
+        Scopes = promoted.Scopes;
+        Description = promoted.Description;
+        Included = promoted.Included;
+        Excluded = promoted.Excluded;
+        Rules = promoted.Rules;
+        Tags = promoted.Tags;
+        IsArchived = promoted.IsArchived;
+
+        CommittedVersion = version;
+        Pending = null;
     }
 }

--- a/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/SegmentConfiguration.cs
+++ b/modules/back-end/src/Infrastructure/Persistence/EntityFrameworkCore/Configurations/SegmentConfiguration.cs
@@ -19,5 +19,11 @@ public class SegmentConfiguration : IEntityTypeConfiguration<Segment>
         builder.Property(x => x.IsArchived).IsRequired();
 
         builder.Property(x => x.Rules).HasColumnType("jsonb");
+
+        // Committed-vs-pending (parity with the Mongo path). CommittedVersion is a plain
+        // bigint column; Pending is a complex object stored as jsonb, mirroring how the
+        // other complex properties above (Rules) are persisted.
+        builder.Property(x => x.CommittedVersion).IsRequired();
+        builder.Property(x => x.Pending).HasColumnType("jsonb");
     }
 }

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/SegmentService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/SegmentService.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Application.Bases.Exceptions;
 using Application.Bases.Models;
 using Application.Segments;
 using Dapper;
@@ -171,6 +172,91 @@ public class SegmentService(AppDbContext dbContext, ILogger<SegmentService> logg
                 caches.Add(new SegmentCache(envIds, sharedSegment));
             }
         }
+    }
+
+    // Committed-vs-pending, Postgres/EF parity with the Mongo SegmentService. Keyed by segment Id
+    // (a segment is a single entity, possibly shared across envs). Matches the Mongo behavior; the
+    // EF promote path has a documented residual non-atomic window (#33).
+
+    public async Task<Segment> GetCommittedAsync(Guid id)
+    {
+        // No-tracking so stripping the pending slot below is purely a read-shaping
+        // operation and never accidentally persisted on a later SaveChanges.
+        var segment = await Queryable
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id);
+        if (segment == null)
+        {
+            throw new EntityNotFoundException(nameof(Segment), id.ToString());
+        }
+
+        // The committed read must NEVER expose a pending (staged) change. The top-level
+        // row is the committed value; drop the pending slot before returning it.
+        segment.Pending = null;
+
+        return segment;
+    }
+
+    public async Task SetPendingAsync(Guid id, Segment pendingValue, long version)
+    {
+        // load the committed row (left otherwise untouched)
+        var segment = await GetAsync(id);
+
+        // write ONLY the pending data; committed fields stay as they are
+        segment.SetPending(pendingValue, version);
+
+        await UpdateAsync(segment);
+    }
+
+    public async Task<bool> PromotePendingAsync(Guid id, long expectedVersion)
+    {
+        var segment = await GetAsync(id);
+
+        // Version guard (#33/#34): only promote if the pending change still matches the version
+        // the caller observed. If it was replaced by a racing SetPendingAsync (different version)
+        // or already promoted (null), do nothing.
+        if (segment.Pending?.Version != expectedVersion)
+        {
+            return false;
+        }
+
+        // promote pending -> committed, then persist the full row so the committed
+        // value advances and the pending slot is cleared.
+        segment.PromotePending();
+
+        // NOTE (#33): without a rowversion/concurrency token there is a residual non-atomic window
+        // between the GetAsync above and SaveChanges here — a racing SetPendingAsync committing in
+        // that window could be overwritten. The in-memory version check narrows but does not close
+        // it for the EF provider; closing it requires an optimistic-concurrency token (tracked in
+        // #33). The Mongo provider closes it via a version-filtered ReplaceOneAsync.
+        await UpdateAsync(segment);
+        return true;
+    }
+
+    public async Task<IReadOnlyList<Segment>> GetPendingAsync()
+    {
+        // Pending is the jsonb column. Postgres translates "pending IS NOT NULL"
+        // for the whole jsonb document, so this is a server-side scan across all segments.
+        return await Queryable
+            .Where(s => s.Pending != null)
+            .ToListAsync();
+    }
+
+    public async Task<IReadOnlyList<Segment>> GetAllCommittedAsync()
+    {
+        // enumerate every segment, then strip the pending slot so only the COMMITTED value is
+        // exposed (mirroring GetCommittedAsync). AsNoTracking so the strip is purely read-shaping
+        // and never persisted.
+        var segments = await Queryable
+            .AsNoTracking()
+            .ToListAsync();
+
+        foreach (var segment in segments)
+        {
+            segment.Pending = null;
+        }
+
+        return segments;
     }
 
     private async Task<(string scope, ICollection<Guid> envIds)> TranslateScopeAsync(string scope)

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/SegmentService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/SegmentService.cs
@@ -178,6 +178,83 @@ public class SegmentService(MongoDbClient mongoDb, ILogger<SegmentService> logge
         }
     }
 
+    public async Task<Segment> GetCommittedAsync(Guid id)
+    {
+        var segment = await GetAsync(id);
+
+        // The committed read must NEVER expose a pending (staged) change. The top-level
+        // document is the committed value; drop the pending slot before returning it.
+        segment.Pending = null;
+
+        return segment;
+    }
+
+    public async Task SetPendingAsync(Guid id, Segment pendingValue, long version)
+    {
+        // ensure the segment exists (committed value is left untouched)
+        await GetAsync(id);
+
+        var pending = new PendingSegmentChange
+        {
+            Version = version,
+            Value = pendingValue
+        };
+
+        var filter = Builders<Segment>.Filter.Eq(x => x.Id, id);
+        var update = Builders<Segment>.Update.Set(x => x.Pending, pending);
+
+        await Collection.UpdateOneAsync(filter, update);
+    }
+
+    public async Task<bool> PromotePendingAsync(Guid id, long expectedVersion)
+    {
+        var segment = await GetAsync(id);
+
+        // Version guard (#33/#34): only promote if the pending change we are about to commit is
+        // still the one the caller observed. If a racing SetPendingAsync replaced it (different
+        // version) or it was already promoted (null), do nothing.
+        if (segment.Pending?.Version != expectedVersion)
+        {
+            return false;
+        }
+
+        // promote pending -> committed in-memory, then persist the full document so the
+        // committed value advances and the pending slot is cleared atomically.
+        segment.PromotePending();
+
+        // Optimistic replace filtered on Pending.Version == expectedVersion: if another writer
+        // staged a new pending version after our read, the filter no longer matches and the
+        // replace is a no-op (MatchedCount == 0), so a concurrent SetPendingAsync cannot be lost
+        // (#33).
+        var filter = Builders<Segment>.Filter.And(
+            Builders<Segment>.Filter.Eq(x => x.Id, id),
+            Builders<Segment>.Filter.Eq(x => x.Pending!.Version, expectedVersion)
+        );
+
+        var result = await Collection.ReplaceOneAsync(filter, segment);
+        return result.MatchedCount > 0;
+    }
+
+    public async Task<IReadOnlyList<Segment>> GetPendingAsync()
+    {
+        // every segment that currently carries a staged change
+        var segments = await FindManyAsync(x => x.Pending != null);
+        return segments.ToList();
+    }
+
+    public async Task<IReadOnlyList<Segment>> GetAllCommittedAsync()
+    {
+        // enumerate every segment, then strip the pending slot so only the COMMITTED value is
+        // exposed (mirroring GetCommittedAsync). The top-level document is the committed value.
+        var segments = await FindManyAsync(_ => true);
+        foreach (var segment in segments)
+        {
+            segment.Pending = null;
+        }
+
+        return segments.ToList();
+    }
+
     private async Task<(string scope, ICollection<Guid> envIds)> TranslateScopeAsync(string scope)
     {
         if (!RN.TryParse(scope, out var props))

--- a/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingPostgresTests.cs
@@ -1,0 +1,232 @@
+using Domain.Segments;
+using Domain.Targeting;
+using Domain.Utils;
+using Infrastructure.Persistence.EntityFrameworkCore;
+using Infrastructure.Services.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+
+namespace Application.IntegrationTests.Segments;
+
+/// <summary>
+/// S1 acceptance (Postgres/EF parity with the Mongo S1 work): the authoritative committed read
+/// must return the COMMITTED segment value, never a pending (staged-but-not-committed) change.
+/// After promotion the committed read returns the new value with an advanced CommittedVersion.
+///
+/// Integration test against a real Postgres instance (throwaway container on port 5436). Uses
+/// EnsureCreated() to materialize the EF model — including the mapped committed_version (bigint)
+/// and pending (jsonb) columns — so this also proves the SegmentConfiguration mapping is valid.
+/// Fails loudly if no Postgres is reachable.
+/// </summary>
+public sealed class SegmentCommittedPendingPostgresTests : IAsyncLifetime
+{
+    private const string BaseConnectionString =
+        "Host=localhost;Port=5436;Database=featbit;Username=postgres;Password=please_change_me";
+
+    // Use a UNIQUE throwaway database per test instance so EnsureCreated/EnsureDeleted in
+    // different tests do not race each other. EF creates and drops this database.
+    private readonly string _dbName = $"featbit_s1_test_{Guid.NewGuid():N}";
+    private string _connectionString = null!;
+    private NpgsqlDataSource _dataSource = null!;
+    private AppDbContext _dbContext = null!;
+    private SegmentService _sut = null!;
+    private readonly Guid _workspaceId = Guid.NewGuid();
+    private readonly Guid _envId = Guid.NewGuid();
+
+    public async Task InitializeAsync()
+    {
+        // fail fast if Postgres is not available. Probe the always-present "postgres" db.
+        var probeConnectionString = new NpgsqlConnectionStringBuilder(BaseConnectionString)
+        {
+            Database = "postgres"
+        }.ConnectionString;
+        await using (var probe = new NpgsqlConnection(probeConnectionString))
+        {
+            await probe.OpenAsync();
+        }
+
+        _connectionString = new NpgsqlConnectionStringBuilder(BaseConnectionString)
+        {
+            Database = _dbName
+        }.ConnectionString;
+
+        // Mirror the production data source: dynamic JSON is required for the jsonb POCO
+        // columns (Rules and the new Pending), and the snake_case naming convention is required
+        // so EnsureCreated materializes the expected committed_version / pending columns.
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(_connectionString);
+        dataSourceBuilder
+            .EnableDynamicJson()
+            .ConfigureJsonOptions(ReusableJsonSerializerOptions.Web);
+        _dataSource = dataSourceBuilder.Build();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(_dataSource)
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        _dbContext = new AppDbContext(options);
+
+        // materializes the EF model (incl. the new committed_version/pending columns)
+        await _dbContext.Database.EnsureCreatedAsync();
+
+        _sut = new SegmentService(_dbContext, NullLogger<SegmentService>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_dbContext != null!)
+        {
+            await _dbContext.Database.EnsureDeletedAsync();
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_dataSource != null!)
+        {
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    private Segment CreateSegment(string key, string description)
+    {
+        return new Segment(
+            workspaceId: _workspaceId,
+            envId: _envId,
+            name: key,
+            key: key,
+            type: SegmentType.EnvironmentSpecific,
+            scopes: [],
+            included: [],
+            excluded: [],
+            rules: new List<MatchRule>(),
+            description: description
+        );
+    }
+
+    [Fact]
+    public async Task SetPending_Then_Promote_Committed_Read_Returns_Old_Then_New_Value()
+    {
+        // Arrange: committed segment, description "old", CommittedVersion = 1
+        var committed = CreateSegment("s1-segment", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        // build the pending value: same segment but description "new"
+        var pendingValue = CreateSegment("s1-segment", "new");
+
+        // Act 1: stage a pending change (version 2)
+        await _sut.SetPendingAsync(committed.Id, pendingValue, version: 2);
+
+        // Assert 1: committed read still returns the OLD value, with no pending leaked
+        var afterStage = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("old", afterStage.Description);
+        Assert.Equal(1, afterStage.CommittedVersion);
+        Assert.Null(afterStage.Pending);
+
+        // sanity: the pending change really was persisted (raw read keeps it)
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(2, raw.Pending!.Version);
+        Assert.Equal("new", raw.Pending.Value.Description);
+
+        // Act 2: promote pending -> committed (guarded on the staged version 2)
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 2);
+        Assert.True(promoted);
+
+        // Assert 2: committed read now returns the NEW value and advanced version
+        var afterPromote = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("new", afterPromote.Description);
+        Assert.Equal(2, afterPromote.CommittedVersion);
+        Assert.Null(afterPromote.Pending);
+
+        // pending slot cleared on the stored row too
+        var rawAfter = await _sut.GetAsync(committed.Id);
+        Assert.Null(rawAfter.Pending);
+    }
+
+    [Fact]
+    public async Task GetCommitted_With_No_Pending_Returns_Committed_Value()
+    {
+        var committed = CreateSegment("s1-no-pending", "value");
+        committed.CommittedVersion = 5;
+        await _sut.AddOneAsync(committed);
+
+        var read = await _sut.GetCommittedAsync(committed.Id);
+
+        Assert.Equal("value", read.Description);
+        Assert.Equal(5, read.CommittedVersion);
+        Assert.Null(read.Pending);
+    }
+
+    [Fact]
+    public async Task PromotePending_Is_NoOp_When_No_Pending()
+    {
+        var committed = CreateSegment("s1-promote-noop", "old");
+        committed.CommittedVersion = 3;
+        await _sut.AddOneAsync(committed);
+
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 4);
+        Assert.False(promoted);
+
+        var read = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("old", read.Description);
+        Assert.Equal(3, read.CommittedVersion);
+        Assert.Null(read.Pending);
+    }
+
+    [Fact]
+    public async Task PromotePending_Is_NoOp_When_Version_Mismatch()
+    {
+        // a stale coordinator (expecting v2) must NOT clobber a newer staged pending (v3) — #33
+        var committed = CreateSegment("s1-version-mismatch", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateSegment("s1-version-mismatch", "new");
+        await _sut.SetPendingAsync(committed.Id, pendingValue, version: 3);
+
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 2);
+        Assert.False(promoted);
+
+        var read = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("old", read.Description);
+        Assert.Equal(1, read.CommittedVersion);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
+    }
+
+    [Fact]
+    public async Task GetPending_Returns_Only_Segments_With_Pending()
+    {
+        var committedOnly = CreateSegment("s1-committed-only", "x");
+        await _sut.AddOneAsync(committedOnly);
+
+        var pendingSeg = CreateSegment("s1-with-pending", "x");
+        await _sut.AddOneAsync(pendingSeg);
+        await _sut.SetPendingAsync(pendingSeg.Id, CreateSegment("s1-with-pending", "y"), version: 2);
+
+        var pending = await _sut.GetPendingAsync();
+
+        Assert.Single(pending);
+        Assert.All(pending, s => Assert.NotNull(s.Pending));
+        Assert.Equal("s1-with-pending", pending[0].Key);
+    }
+
+    [Fact]
+    public async Task GetAllCommitted_Returns_All_Segments_With_Pending_Stripped()
+    {
+        var a = CreateSegment("s1-all-a", "x");
+        await _sut.AddOneAsync(a);
+
+        var b = CreateSegment("s1-all-b", "x");
+        await _sut.AddOneAsync(b);
+        await _sut.SetPendingAsync(b.Id, CreateSegment("s1-all-b", "y"), version: 2);
+
+        var all = await _sut.GetAllCommittedAsync();
+
+        Assert.Equal(2, all.Count);
+        Assert.All(all, s => Assert.Null(s.Pending));
+    }
+}

--- a/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingTests.cs
@@ -1,0 +1,195 @@
+using Domain.Segments;
+using Domain.Targeting;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Application.IntegrationTests.Segments;
+
+/// <summary>
+/// S1 acceptance (Mongo): the authoritative committed read must return the COMMITTED segment
+/// value, never a pending (staged-but-not-committed) change. After promotion the committed read
+/// returns the new value with an advanced CommittedVersion. Promotion is version-guarded.
+///
+/// Integration test against a real MongoDB instance. Uses a UNIQUE throwaway database that is
+/// dropped on dispose. Fails loudly if no Mongo is reachable.
+/// </summary>
+public sealed class SegmentCommittedPendingTests : IAsyncLifetime
+{
+    private const string ConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
+
+    private readonly string _dbName = $"featbit_s1_test_{Guid.NewGuid():N}";
+    private MongoDbClient _mongoDb = null!;
+    private SegmentService _sut = null!;
+    private readonly Guid _workspaceId = Guid.NewGuid();
+    private readonly Guid _envId = Guid.NewGuid();
+
+    public async Task InitializeAsync()
+    {
+        var options = Options.Create(new MongoDbOptions
+        {
+            ConnectionString = ConnectionString,
+            Database = _dbName
+        });
+
+        _mongoDb = new MongoDbClient(options);
+
+        // fail fast / readable skip if Mongo is not available
+        await _mongoDb.Database.RunCommandAsync<MongoDB.Bson.BsonDocument>(
+            new MongoDB.Bson.BsonDocument("ping", 1)
+        );
+
+        _sut = new SegmentService(_mongoDb, NullLogger<SegmentService>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _mongoDb.Database.Client.DropDatabaseAsync(_dbName);
+    }
+
+    private Segment CreateSegment(string key, string description)
+    {
+        return new Segment(
+            workspaceId: _workspaceId,
+            envId: _envId,
+            name: key,
+            key: key,
+            type: SegmentType.EnvironmentSpecific,
+            scopes: [],
+            included: [],
+            excluded: [],
+            rules: new List<MatchRule>(),
+            description: description
+        );
+    }
+
+    [Fact]
+    public async Task SetPending_Then_Promote_Committed_Read_Returns_Old_Then_New_Value()
+    {
+        // Arrange: committed segment, description "old", CommittedVersion = 1
+        var committed = CreateSegment("s1-segment", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        // build the pending value: same segment but description "new"
+        var pendingValue = CreateSegment("s1-segment", "new");
+
+        // Act 1: stage a pending change (version 2)
+        await _sut.SetPendingAsync(committed.Id, pendingValue, version: 2);
+
+        // Assert 1: committed read still returns the OLD value, with no pending leaked
+        var afterStage = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("old", afterStage.Description);
+        Assert.Equal(1, afterStage.CommittedVersion);
+        Assert.Null(afterStage.Pending);
+
+        // sanity: the pending change really was persisted (raw read keeps it)
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(2, raw.Pending!.Version);
+        Assert.Equal("new", raw.Pending.Value.Description);
+
+        // Act 2: promote pending -> committed (guarded on the staged version 2)
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 2);
+        Assert.True(promoted);
+
+        // Assert 2: committed read now returns the NEW value and advanced version
+        var afterPromote = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("new", afterPromote.Description);
+        Assert.Equal(2, afterPromote.CommittedVersion);
+        Assert.Null(afterPromote.Pending);
+
+        // pending slot cleared on the stored document too
+        var rawAfter = await _sut.GetAsync(committed.Id);
+        Assert.Null(rawAfter.Pending);
+    }
+
+    [Fact]
+    public async Task GetCommitted_With_No_Pending_Returns_Committed_Value()
+    {
+        var committed = CreateSegment("s1-no-pending", "value");
+        committed.CommittedVersion = 5;
+        await _sut.AddOneAsync(committed);
+
+        var read = await _sut.GetCommittedAsync(committed.Id);
+
+        Assert.Equal("value", read.Description);
+        Assert.Equal(5, read.CommittedVersion);
+        Assert.Null(read.Pending);
+    }
+
+    [Fact]
+    public async Task PromotePending_Is_NoOp_When_No_Pending()
+    {
+        var committed = CreateSegment("s1-promote-noop", "old");
+        committed.CommittedVersion = 3;
+        await _sut.AddOneAsync(committed);
+
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 4);
+        Assert.False(promoted);
+
+        var read = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("old", read.Description);
+        Assert.Equal(3, read.CommittedVersion);
+        Assert.Null(read.Pending);
+    }
+
+    [Fact]
+    public async Task PromotePending_Is_NoOp_When_Version_Mismatch()
+    {
+        // a stale coordinator (expecting v2) must NOT clobber a newer staged pending (v3) — #33
+        var committed = CreateSegment("s1-version-mismatch", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateSegment("s1-version-mismatch", "new");
+        await _sut.SetPendingAsync(committed.Id, pendingValue, version: 3);
+
+        // coordinator tries to promote expecting the older version 2 -> guard rejects it
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 2);
+        Assert.False(promoted);
+
+        // committed value untouched and the v3 pending is still intact
+        var read = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("old", read.Description);
+        Assert.Equal(1, read.CommittedVersion);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
+    }
+
+    [Fact]
+    public async Task GetPending_Returns_Only_Segments_With_Pending()
+    {
+        var committedOnly = CreateSegment("s1-committed-only", "x");
+        await _sut.AddOneAsync(committedOnly);
+
+        var pendingSeg = CreateSegment("s1-with-pending", "x");
+        await _sut.AddOneAsync(pendingSeg);
+        await _sut.SetPendingAsync(pendingSeg.Id, CreateSegment("s1-with-pending", "y"), version: 2);
+
+        var pending = await _sut.GetPendingAsync();
+
+        Assert.Single(pending);
+        Assert.All(pending, s => Assert.NotNull(s.Pending));
+        Assert.Equal("s1-with-pending", pending[0].Key);
+    }
+
+    [Fact]
+    public async Task GetAllCommitted_Returns_All_Segments_With_Pending_Stripped()
+    {
+        var a = CreateSegment("s1-all-a", "x");
+        await _sut.AddOneAsync(a);
+
+        var b = CreateSegment("s1-all-b", "x");
+        await _sut.AddOneAsync(b);
+        await _sut.SetPendingAsync(b.Id, CreateSegment("s1-all-b", "y"), version: 2);
+
+        var all = await _sut.GetAllCommittedAsync();
+
+        Assert.Equal(2, all.Count);
+        Assert.All(all, s => Assert.Null(s.Pending));
+    }
+}


### PR DESCRIPTION
Part of **#17 (C5)** — the segment equivalent of the merged flag committed/pending work (B3/B4). (#17 stays open until S2 + S3.)

- `Segment`: `CommittedVersion` + nullable `Pending` (`PendingSegmentChange`) + `SetPending`/`PromotePending`.
- `ISegmentService` (keyed by segment Id): `GetCommittedAsync`, `SetPendingAsync`, `PromotePendingAsync(id, expectedVersion)→bool` (optimistic, #33-style), `GetPendingAsync`, `GetAllCommittedAsync` — Mongo + EF.
- `SegmentConfiguration`: `committed_version` bigint + `pending` jsonb; `infra/.../v5.5.2.sql` ALTERs `segments`.

**Verification (real Mongo + Postgres):** 12 integration tests (6 Mongo + 6 Postgres: set-pending→old, promote→new+version, promote no-op on mismatch, GetPending/GetAllCommitted); unit 14/14; full back-end build clean (both paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)