### PR TITLE
✨ Segment stage/commit interface + stage-only handler (S2, part of C5)

### DIFF
--- a/modules/back-end/src/Application/Caches/ICacheService.cs
+++ b/modules/back-end/src/Application/Caches/ICacheService.cs
@@ -35,6 +35,29 @@ public interface ICacheService
 
     Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment);
 
+    /// <summary>
+    /// Stages a new segment version (B2 stage/commit storage) without moving the committed
+    /// pointer or touching any env segment index, so the previously committed value stays
+    /// readable until <see cref="CommitSegmentAsync"/> is called. Mirrors <see cref="StageFlagAsync"/>.
+    /// </summary>
+    Task StageSegmentAsync(Segment segment, long ts);
+
+    /// <summary>
+    /// Commits a previously staged segment version (B2 stage/commit storage): moves the
+    /// committed pointer and advances the segment index to <paramref name="ts"/> for each env
+    /// in <paramref name="envIds"/> (segments can belong to multiple envs). Mirrors
+    /// <see cref="CommitFlagAsync"/>.
+    /// </summary>
+    Task CommitSegmentAsync(ICollection<Guid> envIds, string segmentId, long ts);
+
+    /// <summary>
+    /// Probes whether THIS cache holds the staged version key <c>segment:{id}:v{ts}</c>
+    /// (written by <see cref="StageSegmentAsync"/>). Used by the commit coordinator to
+    /// confirm a staged version is present in a given DC's Redis before committing.
+    /// Mirrors <see cref="HasStagedFlagAsync"/>.
+    /// </summary>
+    Task<bool> HasStagedSegmentAsync(Guid id, long ts);
+
     Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId);
 
     Task UpsertLicenseAsync(Workspace workspace);

--- a/modules/back-end/src/Infrastructure/Caches/None/NoneCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/None/NoneCacheService.cs
@@ -22,6 +22,12 @@ public class NoneCacheService : ICacheService
 
     public Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment) => Task.CompletedTask;
 
+    public Task StageSegmentAsync(Segment segment, long ts) => Task.CompletedTask;
+
+    public Task CommitSegmentAsync(ICollection<Guid> envIds, string segmentId, long ts) => Task.CompletedTask;
+
+    public Task<bool> HasStagedSegmentAsync(Guid id, long ts) => Task.FromResult(false);
+
     public Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId) => Task.CompletedTask;
 
     public Task UpsertLicenseAsync(Workspace workspace) => Task.CompletedTask;

--- a/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
+++ b/modules/back-end/src/Infrastructure/Caches/Redis/RedisCacheService.cs
@@ -122,6 +122,16 @@ public class RedisCacheService(IRedisClient redis) : ICacheService
         }
     }
 
+    /// <summary>
+    /// Probes whether this Redis holds the staged version value key
+    /// <c>featbit:segment:{id}:v{ts}</c> (B2 stage/commit storage, mirroring
+    /// <see cref="HasStagedFlagAsync"/>).
+    /// </summary>
+    public Task<bool> HasStagedSegmentAsync(Guid id, long ts)
+    {
+        return Redis.KeyExistsAsync(RedisCaches.SegmentVersion(id, ts));
+    }
+
     public async Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId)
     {
         // delete cache

--- a/modules/control-plane/src/Api/Application/ControlPlane/SegmentChangeMessageHandler.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/SegmentChangeMessageHandler.cs
@@ -13,6 +13,7 @@ public class SegmentChangeMessageHandler(
     [FromKeyedServices("compositeCache")] ICacheService cacheService,
     IFeatureFlagAppService featureFlagAppService,
     ISegmentMessageService segmentMessageService,
+    ISegmentService segmentService,
     ILogger<SegmentChangeMessageHandler> logger,
     IConfiguration configuration,
     IMessageProducer messageProducer) : IMessageHandler
@@ -44,24 +45,43 @@ public class SegmentChangeMessageHandler(
                 deserializedNotificationNode is not null && deserializedRegionNode is not null &&
                 deserializedRegionNode == configuration.GetRegion())
             {
-                await cacheService
-                    .UpsertSegmentAsync(deserializedEnvIdsNode, deserializedSegmentNonEnvironmentSpecificNode);
-
-                foreach (var envId in deserializedEnvIdsNode)
+                if (configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit)
                 {
-                    var affectedFlags =
-                        await segmentMessageService.GetAffectedFlagsAsync(envId, deserializedNotificationNode);
+                    // GatedCommit (S2): stage the new segment value to every DC's Redis and record
+                    // the Mongo pending change, but do NOT publish the affected-flags / segment
+                    // change to the evaluation-server topics yet. The commit/publish is the
+                    // coordinator's responsibility (S3).
+                    var ts = new DateTimeOffset(deserializedSegmentNonEnvironmentSpecificNode.UpdatedAt)
+                        .ToUnixTimeMilliseconds();
+                    await cacheService.StageSegmentAsync(deserializedSegmentNonEnvironmentSpecificNode, ts);
+                    await segmentService.SetPendingAsync(
+                        deserializedSegmentNonEnvironmentSpecificNode.Id,
+                        deserializedSegmentNonEnvironmentSpecificNode,
+                        ts);
+                }
+                else
+                {
+                    // BestEffort: unchanged upsert + affected-flags propagation.
+                    await cacheService
+                        .UpsertSegmentAsync(deserializedEnvIdsNode, deserializedSegmentNonEnvironmentSpecificNode);
 
-                    // update affected flags
-                    if (affectedFlags.Count > 0)
+                    foreach (var envId in deserializedEnvIdsNode)
                     {
-                        await featureFlagAppService.OnSegmentUpdatedAsync(deserializedSegmentNonEnvironmentSpecificNode,
-                            deserializedNotificationNode.OperatorId, affectedFlags);
-                    }
+                        var affectedFlags =
+                            await segmentMessageService.GetAffectedFlagsAsync(envId, deserializedNotificationNode);
 
-                    // publish segment change message
-                    await segmentMessageService.PublishSegmentChangeMessage(envId, affectedFlags,
-                        deserializedSegmentNonEnvironmentSpecificNode);
+                        // update affected flags
+                        if (affectedFlags.Count > 0)
+                        {
+                            await featureFlagAppService.OnSegmentUpdatedAsync(
+                                deserializedSegmentNonEnvironmentSpecificNode,
+                                deserializedNotificationNode.OperatorId, affectedFlags);
+                        }
+
+                        // publish segment change message
+                        await segmentMessageService.PublishSegmentChangeMessage(envId, affectedFlags,
+                            deserializedSegmentNonEnvironmentSpecificNode);
+                    }
                 }
 
                 var webHooksMessage = new

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -47,6 +47,21 @@ public class CompositeRedisCacheService(
     public Task UpsertSegmentAsync(ICollection<Guid> envIds, Segment segment) =>
         BroadcastAsync(s => s.UpsertSegmentAsync(envIds, segment), nameof(UpsertSegmentAsync));
 
+    public Task StageSegmentAsync(Segment segment, long ts) =>
+        BroadcastAsync(s => s.StageSegmentAsync(segment, ts), nameof(StageSegmentAsync));
+
+    public Task CommitSegmentAsync(ICollection<Guid> envIds, string segmentId, long ts) =>
+        BroadcastAsync(s => s.CommitSegmentAsync(envIds, segmentId, ts), nameof(CommitSegmentAsync));
+
+    // ICacheService probe: returns the LOCAL DC's result (first instance), mirroring
+    // HasStagedFlagAsync. This is NOT the coordinator API — the coordinator must use
+    // GetStagedSegmentDcsAsync to see EVERY DC's staged presence.
+    public Task<bool> HasStagedSegmentAsync(Guid id, long ts)
+    {
+        var local = cacheServices.First();
+        return local.Service.HasStagedSegmentAsync(id, ts);
+    }
+
     public Task DeleteSegmentAsync(ICollection<Guid> envIds, Guid segmentId) =>
         BroadcastAsync(s => s.DeleteSegmentAsync(envIds, segmentId), nameof(DeleteSegmentAsync));
 
@@ -158,6 +173,31 @@ public class CompositeRedisCacheService(
     }
 
     /// <summary>
+    /// Coordinator-facing probe (segment counterpart of <see cref="GetStagedDcsAsync"/>):
+    /// returns, per <see cref="DcCacheService.DcId"/>, whether that DC's Redis holds the staged
+    /// version <c>segment:{id}:v{ts}</c>. Iterates every configured DC (unlike the local-first
+    /// <see cref="HasStagedSegmentAsync"/>) with the same swallow-and-continue resilience: a DC
+    /// whose probe throws is reported as <c>false</c> rather than failing the whole call.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, bool>> GetStagedSegmentDcsAsync(Guid id, long ts)
+    {
+        var instances = cacheServices.ToList();
+        var tasks = instances
+            .Select(dc => ProbeStagedSegmentSafelyAsync(dc, id, ts))
+            .ToList();
+
+        var outcomes = await Task.WhenAll(tasks);
+
+        var results = new Dictionary<string, bool>(outcomes.Length);
+        for (var i = 0; i < outcomes.Length; i++)
+        {
+            results[instances[i].DcId] = outcomes[i];
+        }
+
+        return results;
+    }
+
+    /// <summary>
     /// Recovery-facing targeted write (E1): stages <paramref name="flag"/> at version
     /// <paramref name="ts"/> into ONE DC's Redis (the <see cref="DcCacheService"/> whose
     /// <see cref="DcCacheService.DcId"/> matches <paramref name="dcId"/>), unlike the broadcast
@@ -207,6 +247,27 @@ public class CompositeRedisCacheService(
             logger.LogError(
                 ex,
                 "Staged-flag probe failed for DC {DcId} (implementation {CacheService}). Reporting not-staged.",
+                dc.DcId,
+                dc.Service.GetType().FullName);
+            return false;
+        }
+    }
+
+    private async Task<bool> ProbeStagedSegmentSafelyAsync(DcCacheService dc, Guid id, long ts)
+    {
+        try
+        {
+            return await dc.Service.HasStagedSegmentAsync(id, ts);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Staged-segment probe failed for DC {DcId} (implementation {CacheService}). Reporting not-staged.",
                 dc.DcId,
                 dc.Service.GetType().FullName);
             return false;

--- a/modules/control-plane/tests/Api.IntegrationTests/Caches/CompositeRedisGetStagedSegmentDcsTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/Caches/CompositeRedisGetStagedSegmentDcsTests.cs
@@ -1,0 +1,110 @@
+using Api.Infrastructure.Caches;
+using Domain.Segments;
+using Infrastructure.Caches.Redis;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+
+namespace Api.IntegrationTests.Caches;
+
+/// <summary>
+/// S2 (coordinator API): CompositeRedisCacheService.GetStagedSegmentDcsAsync returns, per
+/// DcId, whether THAT DC's Redis holds the staged version segment:{id}:v{ts}. Segment
+/// counterpart of <see cref="CompositeRedisGetStagedDcsTests"/>.
+///
+/// Two DCs are simulated by two RedisCacheService instances bound to two logical Redis DB
+/// indexes (0 = west, 1 = east) on a single throwaway Redis. Staging into west's DB only must
+/// produce a per-DcId map showing present in west and absent in east.
+///
+/// Requires a real Redis on a NON-default port (6388). Override via S2_REDIS env var. Fails
+/// loudly if Redis is unreachable.
+/// </summary>
+public class CompositeRedisGetStagedSegmentDcsTests : IAsyncLifetime
+{
+    private const string DefaultConnection = "localhost:6388";
+    private const string WestDcId = "dc-west";
+    private const string EastDcId = "dc-east";
+
+    private ConnectionMultiplexer? _mux;
+
+    private static string ConnectionString =>
+        Environment.GetEnvironmentVariable("S2_REDIS") ?? DefaultConnection;
+
+    public async Task InitializeAsync()
+    {
+        var options = ConfigurationOptions.Parse(ConnectionString);
+        options.AbortOnConnectFail = false;
+        options.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(options);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{ConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6388:6379 --name s2-redis redis:7-alpine " +
+                "(or set the S2_REDIS env var).");
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _mux?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task GetStagedSegmentDcs_ReportsPerDc_StagedPresence()
+    {
+        // west -> logical db 0, east -> logical db 1 (independent keyspaces on one server)
+        var west = new RedisCacheService(new TestRedisClient(_mux!, db: 0));
+        var east = new RedisCacheService(new TestRedisClient(_mux!, db: 1));
+
+        var sut = new CompositeRedisCacheService(
+            new[]
+            {
+                new DcCacheService(WestDcId, west),
+                new DcCacheService(EastDcId, east)
+            },
+            NullLogger<CompositeRedisCacheService>.Instance);
+
+        var segmentId = Guid.NewGuid();
+        var ts = 12_000L;
+
+        // stage the version into WEST's Redis only
+        await west.StageSegmentAsync(NewSegment(segmentId, ts), ts);
+
+        var map = await sut.GetStagedSegmentDcsAsync(segmentId, ts);
+
+        Assert.Equal(2, map.Count);
+        Assert.True(map[WestDcId], "west staged the version, so its DC should report present");
+        Assert.False(map[EastDcId], "east never staged the version, so its DC should report absent");
+
+        // sanity: the ICacheService probe is local-first (west = first instance) -> true
+        Assert.True(await sut.HasStagedSegmentAsync(segmentId, ts));
+
+        // cleanup
+        await _mux!.GetDatabase(0).KeyDeleteAsync(RedisCaches.SegmentVersion(segmentId, ts));
+    }
+
+    private static Segment NewSegment(Guid segmentId, long ts) => new(
+        workspaceId: Guid.NewGuid(),
+        envId: Guid.NewGuid(),
+        name: "test-segment",
+        key: "test-segment",
+        type: SegmentType.EnvironmentSpecific,
+        scopes: [],
+        included: [],
+        excluded: [],
+        rules: [],
+        description: string.Empty)
+    {
+        Id = segmentId,
+        UpdatedAt = DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime
+    };
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase(db);
+    }
+}

--- a/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/SegmentChangeMessageHandlerTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/SegmentChangeMessageHandlerTests.cs
@@ -13,21 +13,57 @@ namespace Api.UnitTests.Application.ControlPlane;
 
 public class SegmentChangeMessageHandlerTests
 {
+    private const string Region = "us-east-1";
+
     private readonly Mock<ICacheService> _cache = new();
     private readonly Mock<IFeatureFlagAppService> _ff = new();
     private readonly Mock<ISegmentMessageService> _segSvc = new();
+    private readonly Mock<ISegmentService> _segmentService = new();
     private readonly Mock<ILogger<SegmentChangeMessageHandler>> _logger = new();
-    private readonly Mock<IConfiguration> _config = new();
     private readonly Mock<IMessageProducer> _producer = new();
 
-    private SegmentChangeMessageHandler CreateSut()
-        => new(_cache.Object, _ff.Object, _segSvc.Object, _logger.Object, _config.Object, _producer.Object);
+    private static IConfiguration BuildConfiguration(string? consistencyMode)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["Region"] = Region
+        };
+
+        if (consistencyMode != null)
+        {
+            values["ControlPlane:ConsistencyMode"] = consistencyMode;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private SegmentChangeMessageHandler CreateSut(string? consistencyMode = null)
+        => new(
+            _cache.Object,
+            _ff.Object,
+            _segSvc.Object,
+            _segmentService.Object,
+            _logger.Object,
+            BuildConfiguration(consistencyMode),
+            _producer.Object);
+
+    private static string BuildMessage(Guid env1, Guid env2, Guid segmentId, DateTime updatedAt)
+    {
+        return $$"""
+                 {
+                   "segmentNonSpecific": { "id": "{{segmentId}}", "updatedAt": "{{updatedAt:O}}" },
+                   "envIds": ["{{env1}}","{{env2}}"],
+                   "notification": {},
+                   "region": "{{Region}}"
+                 }
+                 """;
+    }
 
     [Fact]
     public async Task HandleAsync_WhenRequiredPropertiesMissing_Throws()
     {
         var sut = CreateSut();
-        
+
         var payload = """{"anything":"else"}""";
 
         await Assert.ThrowsAsync<InvalidDataException>(() => sut.HandleAsync(payload));
@@ -42,7 +78,7 @@ public class SegmentChangeMessageHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenValidPayload_UpsertsSegment_AndPublishesForEachEnv()
+    public async Task HandleAsync_BestEffort_UpsertsSegment_AndPublishesForEachEnv()
     {
         _segSvc
             .Setup(x => x.GetAffectedFlagsAsync(It.IsAny<Guid>(), It.IsAny<OnSegmentChange>()))
@@ -52,29 +88,18 @@ public class SegmentChangeMessageHandlerTests
             .Setup(x => x.PublishSegmentChangeMessage(It.IsAny<Guid>(), It.IsAny<ICollection<FlagReference>>(),
                 It.IsAny<Segment>()))
             .Returns(Task.CompletedTask);
-        
-        _config
-            .Setup(x => x.GetSection(It.IsAny<string>()).Value)
-            .Returns("us-east-1");
 
-        var sut = CreateSut();
+        var sut = CreateSut(consistencyMode: "BestEffort");
 
         var env1 = Guid.NewGuid();
         var env2 = Guid.NewGuid();
 
-        var payload = $$"""
-                        {
-                          "segmentNonSpecific": {},
-                          "envIds": ["{{env1}}","{{env2}}"],
-                          "notification": {},
-                          "region": "us-east-1"
-                        }
-                        """;
+        var payload = BuildMessage(env1, env2, Guid.NewGuid(), DateTime.UtcNow);
 
         await sut.HandleAsync(payload);
 
         _cache.Verify(x => x.UpsertSegmentAsync(It.IsAny<ICollection<Guid>>(), It.IsAny<Segment>()), Times.Once);
-        
+
         _ff.Verify(
             x => x.OnSegmentUpdatedAsync(It.IsAny<Segment>(), It.IsAny<Guid>(), It.IsAny<ICollection<FlagReference>>()),
             Times.Never);
@@ -85,5 +110,66 @@ public class SegmentChangeMessageHandlerTests
         _segSvc.Verify(
             x => x.PublishSegmentChangeMessage(env2, It.IsAny<ICollection<FlagReference>>(), It.IsAny<Segment>()),
             Times.Once);
+
+        // BestEffort must NOT use the stage/commit path.
+        _cache.Verify(x => x.StageSegmentAsync(It.IsAny<Segment>(), It.IsAny<long>()), Times.Never);
+        _segmentService.Verify(
+            x => x.SetPendingAsync(It.IsAny<Guid>(), It.IsAny<Segment>(), It.IsAny<long>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenModeUnset_DefaultsToBestEffort()
+    {
+        _segSvc
+            .Setup(x => x.GetAffectedFlagsAsync(It.IsAny<Guid>(), It.IsAny<OnSegmentChange>()))
+            .ReturnsAsync(new Collection<FlagReference>());
+
+        var sut = CreateSut(consistencyMode: null);
+
+        var env1 = Guid.NewGuid();
+        var env2 = Guid.NewGuid();
+
+        var payload = BuildMessage(env1, env2, Guid.NewGuid(), DateTime.UtcNow);
+
+        await sut.HandleAsync(payload);
+
+        _cache.Verify(x => x.UpsertSegmentAsync(It.IsAny<ICollection<Guid>>(), It.IsAny<Segment>()), Times.Once);
+        _cache.Verify(x => x.StageSegmentAsync(It.IsAny<Segment>(), It.IsAny<long>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_GatedCommit_StagesAndSetsPending_DoesNotPublishSegmentChange()
+    {
+        var sut = CreateSut(consistencyMode: "GatedCommit");
+
+        var env1 = Guid.NewGuid();
+        var env2 = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        var updatedAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var expectedTs = new DateTimeOffset(updatedAt).ToUnixTimeMilliseconds();
+
+        var payload = BuildMessage(env1, env2, segmentId, updatedAt);
+
+        await sut.HandleAsync(payload);
+
+        _cache.Verify(
+            x => x.StageSegmentAsync(It.Is<Segment>(s => s.Id == segmentId), expectedTs),
+            Times.Once);
+        _segmentService.Verify(
+            x => x.SetPendingAsync(segmentId, It.Is<Segment>(s => s.Id == segmentId), expectedTs),
+            Times.Once);
+
+        // GatedCommit must hold the affected-flags / segment-change propagation for the coordinator.
+        _cache.Verify(x => x.UpsertSegmentAsync(It.IsAny<ICollection<Guid>>(), It.IsAny<Segment>()), Times.Never);
+        _ff.Verify(
+            x => x.OnSegmentUpdatedAsync(It.IsAny<Segment>(), It.IsAny<Guid>(), It.IsAny<ICollection<FlagReference>>()),
+            Times.Never);
+        _segSvc.Verify(
+            x => x.PublishSegmentChangeMessage(
+                It.IsAny<Guid>(), It.IsAny<ICollection<FlagReference>>(), It.IsAny<Segment>()),
+            Times.Never);
+        _segSvc.Verify(
+            x => x.GetAffectedFlagsAsync(It.IsAny<Guid>(), It.IsAny<OnSegmentChange>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
Part of **#17 (C5)** — segment equivalent of C2 + C3b-1. (#17 stays open until S3.)

- `ICacheService`: `StageSegmentAsync`/`CommitSegmentAsync` (concrete existed from B2) + `HasStagedSegmentAsync` (None=false; composite broadcast + local-first + per-DC `GetStagedSegmentDcsAsync`).
- `SegmentChangeMessageHandler`: under **GatedCommit**, `StageSegmentAsync` to all DCs + `SetPendingAsync`, **holding** the affected-flags / `PublishSegmentChangeMessage` propagation for the coordinator (S3). **BestEffort** path moved verbatim to the `else` branch (upsert + per-env affected-flags publish unchanged).

**Verification:** CP unit 52/52 (5 handler tests: both modes, mode-unset default, missing-props, invalid-json — asserts GatedCommit never calls the affected-flags path); segment per-DC probe integration (real Redis :6388); back-end 14/14; both builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)