### PR TITLE
✨ Coordinator commits pending segments (S3) — completes C5

### DIFF
--- a/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
@@ -2,8 +2,10 @@ using System.Diagnostics.Metrics;
 using Application.Caches;
 using Application.Configuration;
 using Application.ControlPlane;
+using Application.Segments;
 using Application.Services;
 using Api.Infrastructure.Caches;
+using Domain.AuditLogs;
 using Domain.FeatureFlags;
 using Domain.Messages;
 using Microsoft.Extensions.Configuration;
@@ -15,18 +17,30 @@ namespace Api.Application.ControlPlane;
 
 /// <summary>
 /// C3b-2 commit coordinator. Under <see cref="ConsistencyMode.GatedCommit"/> this periodically
-/// reconciles pending (staged-but-not-committed) flag changes: a pending version is committed
-/// (its committed pointer/index advanced in every DC's Redis, the Mongo/EF pending promoted to
-/// committed, and the change published to the evaluation-server topic) only once EVERY currently
-/// live DC has that exact version staged in its own Redis.
+/// reconciles pending (staged-but-not-committed) flag AND segment changes: a pending version is
+/// committed (its committed pointer/index advanced in every DC's Redis, the Mongo/EF pending
+/// promoted to committed, and the change published to the evaluation-server topic) only once
+/// EVERY currently live DC has that exact version staged in its own Redis.
 ///
 /// Gate model (locked design): the control plane probes each live DC's Redis directly
-/// (<see cref="CompositeRedisCacheService.GetStagedDcsAsync"/>) — "live" = a DC with at least one
-/// unexpired lease in <see cref="ILeaseStore"/>. The pending set is enumerated via a DB scan
-/// (<see cref="IFeatureFlagService.GetPendingAsync"/>); commit granularity is per-flag.
+/// (<see cref="CompositeRedisCacheService.GetStagedDcsAsync"/> for flags,
+/// <see cref="CompositeRedisCacheService.GetStagedSegmentDcsAsync"/> for segments) — "live" = a DC
+/// with at least one unexpired lease in <see cref="ILeaseStore"/>. The pending sets are enumerated
+/// via DB scans (<see cref="IFeatureFlagService.GetPendingAsync"/> /
+/// <see cref="ISegmentService.GetPendingAsync"/>); commit granularity is per-flag / per-segment.
 ///
-/// Idempotent + crash-safe: re-running a tick is a no-op once a flag is committed — the commit
-/// broadcast and the version-guarded promote both no-op when already applied.
+/// Segments (S3 / #17): committing a segment additionally replays the affected-flags propagation
+/// that <see cref="SegmentChangeMessageHandler"/>'s BestEffort branch performs inline at handle
+/// time. Because the staged pending change does NOT carry the original change notification, the
+/// coordinator reconstructs an <see cref="OnSegmentChange"/> (Operation = Update,
+/// IsTargetingChange = true) from the committed segment so
+/// <see cref="ISegmentMessageService.GetAffectedFlagsAsync"/> recomputes the affected flags, then
+/// (if any) calls <see cref="IFeatureFlagAppService.OnSegmentUpdatedAsync"/> and finally
+/// <see cref="ISegmentMessageService.PublishSegmentChangeMessage"/> per env — exactly the
+/// BestEffort sequence, deferred to commit time.
+///
+/// Idempotent + crash-safe: re-running a tick is a no-op once a flag/segment is committed — the
+/// commit broadcast and the version-guarded promote both no-op when already applied.
 ///
 /// TODO: single-instance/leader election if the control plane runs multiple replicas. Today
 /// multiple replicas would each run this loop; the commit + version-guarded promote are idempotent
@@ -107,7 +121,7 @@ public sealed class CommitCoordinatorWorker : BackgroundService
                 if (committed > 0)
                 {
                     _logger.LogInformation(
-                        "Commit coordinator committed {CommittedCount} pending flag change(s).",
+                        "Commit coordinator committed {CommittedCount} pending flag/segment change(s).",
                         committed);
                 }
             }
@@ -123,24 +137,32 @@ public sealed class CommitCoordinatorWorker : BackgroundService
     }
 
     /// <summary>
-    /// Performs a single coordinator tick and returns the number of flags committed. Exposed so it
-    /// can be invoked directly (e.g. by integration tests) without waiting on the periodic timer.
+    /// Performs a single coordinator tick and returns the number of flags AND segments committed.
+    /// Exposed so it can be invoked directly (e.g. by integration tests) without waiting on the
+    /// periodic timer.
     ///
     /// For each pending flag whose pending version is newer than its committed version, if every
     /// currently live DC has that version staged, the flag is committed across all DCs, its pending
     /// is promoted (version-guarded), and the change is published to the evaluation-server topic.
-    /// Otherwise the flag is left pending and retried on the next tick.
+    /// Pending segments are then reconciled the same way; committing a segment additionally replays
+    /// the affected-flags propagation (see the type summary). Anything not yet staged everywhere is
+    /// left pending and retried on the next tick.
     /// </summary>
     public async Task<int> RunOnceAsync(CancellationToken cancellationToken = default)
     {
         // IFeatureFlagService is a scoped (per-request) service in DI; resolve it inside a scope so
-        // the singleton BackgroundService does not capture a scoped/disposed instance.
+        // the singleton BackgroundService does not capture a scoped/disposed instance. The segment
+        // services are resolved from the SAME scope, matching the flag path.
         using var scope = _scopeFactory.CreateScope();
         var featureFlagService = scope.ServiceProvider.GetRequiredService<IFeatureFlagService>();
         var leaseStore = scope.ServiceProvider.GetRequiredService<ILeaseStore>();
 
         var pending = await featureFlagService.GetPendingAsync();
-        if (pending.Count == 0)
+        var pendingSegments = await scope.ServiceProvider
+            .GetRequiredService<ISegmentService>()
+            .GetPendingAsync();
+
+        if (pending.Count == 0 && pendingSegments.Count == 0)
         {
             return 0;
         }
@@ -239,6 +261,120 @@ public sealed class CommitCoordinatorWorker : BackgroundService
                     flag.Id,
                     version,
                     string.Join(", ", evictedDcs));
+            }
+        }
+
+        // ---- Segment loop (S3 / #17): mirrors the flag loop above. ----
+        if (pendingSegments.Count > 0)
+        {
+            // Resolve the segment-side services from the SAME per-tick scope, exactly like the flag
+            // services. These are the services SegmentChangeMessageHandler's BestEffort branch uses
+            // for the affected-flags propagation we replicate at commit time.
+            var segmentService = scope.ServiceProvider.GetRequiredService<ISegmentService>();
+            var segmentMessageService = scope.ServiceProvider.GetRequiredService<ISegmentMessageService>();
+            var featureFlagAppService = scope.ServiceProvider.GetRequiredService<IFeatureFlagAppService>();
+
+            foreach (var segment in pendingSegments)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var pendingChange = segment.Pending;
+                if (pendingChange == null)
+                {
+                    continue;
+                }
+
+                // V is the staged Redis version, which S2 sets to UpdatedAt-as-unix-ms when staging
+                // (PendingSegmentChange.Version == ToUnixTimeMilliseconds(UpdatedAt)).
+                var version = pendingChange.Version;
+
+                // Monotonicity (#34): never commit a version that is not strictly newer than what is
+                // already committed. Skips stale/duplicate pending rows.
+                if (version <= segment.CommittedVersion)
+                {
+                    continue;
+                }
+
+                var stagedMap = await composite.GetStagedSegmentDcsAsync(segment.Id, version);
+
+                // Gate: EVERY live DC must have this exact version staged. A DC missing from the map,
+                // or present-but-false, blocks the commit (we retry next tick once it catches up).
+                var allLiveStaged = liveDcs.All(dc => stagedMap.TryGetValue(dc, out var staged) && staged);
+                if (!allLiveStaged)
+                {
+                    continue;
+                }
+
+                // The env set is needed both to advance the committed pointer/index in Redis and to
+                // drive the per-env affected-flags propagation below.
+                var envIds = await segmentService.GetEnvironmentIdsAsync(segment);
+
+                // Broadcast the commit to all DCs: advance the committed pointer + index everywhere.
+                await composite.CommitSegmentAsync(envIds, segment.Id.ToString(), version);
+
+                // Version-guarded promote of the DB pending -> committed. If a racing SetPendingAsync
+                // replaced the pending version since GetPendingAsync read it, the guard makes this a
+                // no-op and we do NOT publish a stale value.
+                var promoted = await segmentService.PromotePendingAsync(segment.Id, version);
+                if (!promoted)
+                {
+                    continue;
+                }
+
+                // Replicate SegmentChangeMessageHandler's BestEffort affected-flags propagation,
+                // deferred to commit time. The staged pending change does not carry the original
+                // notification, so reconstruct one from the (now committed) segment as an Update with
+                // IsTargetingChange = true, so GetAffectedFlagsAsync recomputes the affected flags.
+                var committedSegment = await segmentService.GetCommittedAsync(segment.Id);
+                var notification = new OnSegmentChange(
+                    committedSegment,
+                    Operations.Update,
+                    // DataChange drives only the audit log (not exercised on this propagation path),
+                    // so an empty change is sufficient here.
+                    new DataChange(),
+                    operatorId: Guid.Empty,
+                    isTargetingChange: true);
+
+                foreach (var envId in envIds)
+                {
+                    var affectedFlags =
+                        await segmentMessageService.GetAffectedFlagsAsync(envId, notification);
+
+                    // update affected flags
+                    if (affectedFlags.Count > 0)
+                    {
+                        await featureFlagAppService.OnSegmentUpdatedAsync(
+                            committedSegment,
+                            notification.OperatorId,
+                            affectedFlags);
+                    }
+
+                    // publish segment change message
+                    await segmentMessageService.PublishSegmentChangeMessage(envId, affectedFlags, committedSegment);
+                }
+
+                count++;
+
+                // Observability (#16): mirror the flag path — record any CONFIGURED DC that was
+                // evicted (present in the probed staged map's keys but absent from the live set).
+                // This does not change the commit decision (made on the live set by design).
+                var evictedDcs = stagedMap.Keys
+                    .Where(dc => !liveDcs.Contains(dc))
+                    .ToList();
+
+                if (evictedDcs.Count > 0)
+                {
+                    foreach (var dc in evictedDcs)
+                    {
+                        EvictedCommitCounter.Add(1, new KeyValuePair<string, object?>("dc_id", dc));
+                    }
+
+                    _logger.LogWarning(
+                        "Committed segment {SegmentId} v{Version} without DC(s) {EvictedDcs} — proceeding on live set.",
+                        segment.Id,
+                        version,
+                        string.Join(", ", evictedDcs));
+                }
             }
         }
 

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/SegmentCommitCoordinatorWorkerTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/SegmentCommitCoordinatorWorkerTests.cs
@@ -2,10 +2,12 @@ using Api.Application.ControlPlane;
 using Api.Infrastructure.Caches;
 using Application.Caches;
 using Application.ControlPlane;
+using Application.Segments;
 using Application.Services;
 using Domain.ControlPlane;
 using Domain.FeatureFlags;
 using Domain.Messages;
+using Domain.Segments;
 using Infrastructure.Caches.Redis;
 using Infrastructure.Persistence.MongoDb;
 using Infrastructure.Services.MongoDb;
@@ -21,30 +23,35 @@ using StackExchange.Redis;
 namespace Api.IntegrationTests.ControlPlane;
 
 /// <summary>
-/// C3b-2 commit coordinator acceptance tests. Exercises the locked design end-to-end against real
-/// infrastructure: a real MongoDB (pending flags + DC leases) and a real Redis whose two logical DB
-/// indexes simulate two DCs' Redis (dc-a = db 0, dc-b = db 1). The coordinator commits a pending
-/// version only once EVERY live DC has it staged.
+/// S3 (#17) commit coordinator SEGMENT acceptance tests. Mirrors
+/// <see cref="CommitCoordinatorWorkerTests"/> for the segment loop: a pending (staged-but-not-
+/// committed) segment version is committed only once EVERY live DC has it staged. On commit, the
+/// committed pointer/index is advanced in every DC's Redis, the Mongo pending is promoted
+/// (version-guarded), and the affected-flags segment-change is published per env (replicating
+/// SegmentChangeMessageHandler's BestEffort propagation, deferred to commit time).
 ///
-/// Requires:
+/// Real infra (fails loudly, never silently skips):
 ///  - MongoDB at mongodb://admin:password@localhost:27017 (unique throwaway DB, dropped on dispose).
-///  - Redis on port 6384 (override via C3B2_REDIS):
-///      docker run -d --rm -p 6384:6379 --name c3b2-redis redis:7-alpine
-/// Fails loudly (not silently skips) if either is unreachable.
+///  - Redis on port 6389 (override via S3_REDIS): two logical DB indexes simulate two DCs
+///    (dc-a = db 0, dc-b = db 1).
+///      docker run -d --rm -p 6389:6379 --name s3-redis redis:7-alpine
+///
+/// The segment publish is spied via a fake <see cref="ISegmentMessageService"/> so the tests assert
+/// the per-env segment change fires ONLY on commit.
 /// </summary>
-public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
+public sealed class SegmentCommitCoordinatorWorkerTests : IAsyncLifetime
 {
     private const string MongoConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
-    private const string DefaultRedis = "localhost:6384";
+    private const string DefaultRedis = "localhost:6389";
 
     private const string DcA = "dc-a";
     private const string DcB = "dc-b";
 
-    private readonly string _dbName = $"featbit_c3b2_test_{Guid.NewGuid():N}";
+    private readonly string _dbName = $"featbit_s3_test_{Guid.NewGuid():N}";
     private readonly Guid _envId = Guid.NewGuid();
 
     private MongoDbClient _mongoDb = null!;
-    private FeatureFlagService _flagService = null!;
+    private SegmentService _segmentService = null!;
     private MongoLeaseStore _leaseStore = null!;
 
     private ConnectionMultiplexer _mux = null!;
@@ -53,7 +60,7 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
     private CompositeRedisCacheService _composite = null!;
 
     private static string RedisConnectionString =>
-        Environment.GetEnvironmentVariable("C3B2_REDIS") ?? DefaultRedis;
+        Environment.GetEnvironmentVariable("S3_REDIS") ?? DefaultRedis;
 
     public async Task InitializeAsync()
     {
@@ -66,7 +73,7 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         _mongoDb = new MongoDbClient(options);
         await _mongoDb.Database.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1));
 
-        _flagService = new FeatureFlagService(_mongoDb);
+        _segmentService = new SegmentService(_mongoDb, NullLogger<SegmentService>.Instance);
         _leaseStore = new MongoLeaseStore(_mongoDb);
 
         // ---- Redis (two DB indexes = two DCs) ----
@@ -79,8 +86,8 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         {
             throw new InvalidOperationException(
                 $"No Redis reachable at '{RedisConnectionString}'. Start one with: " +
-                "docker run -d --rm -p 6384:6379 --name c3b2-redis redis:7-alpine " +
-                "(or set the C3B2_REDIS env var).");
+                "docker run -d --rm -p 6389:6379 --name s3-redis redis:7-alpine " +
+                "(or set the S3_REDIS env var).");
         }
 
         _dcaCache = new RedisCacheService(new TestRedisClient(_mux, db: 0));
@@ -97,7 +104,6 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        // flush both DC DB indexes so a shared Redis is left clean
         await _mux.GetDatabase(0).ExecuteAsync("FLUSHDB");
         await _mux.GetDatabase(1).ExecuteAsync("FLUSHDB");
         _mux.Dispose();
@@ -107,47 +113,41 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
 
     // ----- helpers -----
 
-    private FeatureFlag CreateFlag(string key, bool isEnabled)
+    private Segment CreateSegment(string key, params string[] included)
     {
-        var enabledVariationId = Guid.NewGuid().ToString();
-        var disabledVariationId = Guid.NewGuid().ToString();
-
-        var variations = new List<Variation>
-        {
-            new() { Id = enabledVariationId, Name = "true", Value = "true" },
-            new() { Id = disabledVariationId, Name = "false", Value = "false" }
-        };
-
-        return new FeatureFlag(
+        return new Segment(
+            workspaceId: Guid.NewGuid(),
             envId: _envId,
             name: key,
-            description: string.Empty,
             key: key,
-            isEnabled: isEnabled,
-            variationType: "boolean",
-            variations: variations,
-            disabledVariationId: disabledVariationId,
-            enabledVariationId: enabledVariationId,
-            tags: [],
-            currentUserId: Guid.NewGuid()
-        );
+            type: SegmentType.EnvironmentSpecific,
+            scopes: [],
+            included: included,
+            excluded: [],
+            rules: [],
+            description: string.Empty);
     }
 
-    /// <summary>Seeds a committed flag (v1, disabled) with a staged pending change (v2, enabled).</summary>
-    private async Task<(FeatureFlag committed, FeatureFlag pendingValue, long pendingVersion)> SeedCommittedV1PendingV2(string key)
+    /// <summary>
+    /// Seeds a committed segment (v1, included=["alice"]) with a staged pending change
+    /// (v2, included=["bob"]). The pending value carries the SAME Id and its
+    /// <c>UpdatedAt</c> is set so its unix-ms equals the pending version, matching how S2 stages.
+    /// </summary>
+    private async Task<long> SeedCommittedV1PendingV2(string key)
     {
-        var committed = CreateFlag(key, isEnabled: false);
+        var committed = CreateSegment(key, "alice");
         committed.CommittedVersion = 1;
-        await _flagService.AddOneAsync(committed);
+        await _segmentService.AddOneAsync(committed);
 
-        // the pending value is an edit of the SAME flag entity, so it carries the same Id (the
-        // staged Redis key and the coordinator's probe are both keyed on flag.Id)
-        var pendingValue = CreateFlag(key, isEnabled: true);
-        pendingValue.Id = committed.Id;
         const long pendingVersion = 2;
-        await _flagService.SetPendingAsync(_envId, key, pendingValue, pendingVersion);
 
-        return (committed, pendingValue, pendingVersion);
+        var pendingValue = CreateSegment(key, "bob");
+        pendingValue.Id = committed.Id;
+        pendingValue.UpdatedAt = DateTimeOffset.FromUnixTimeMilliseconds(pendingVersion).UtcDateTime;
+
+        await _segmentService.SetPendingAsync(committed.Id, pendingValue, pendingVersion);
+
+        return pendingVersion;
     }
 
     private async Task UpsertLeaseAsync(string dcId, DateTimeOffset expiresAt)
@@ -162,17 +162,18 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
     }
 
     private CommitCoordinatorWorker CreateSut(
-        SpyMessageProducer producer,
+        SpySegmentMessageService segmentMessages,
         ILogger<CommitCoordinatorWorker>? logger = null)
     {
-        // Wire IFeatureFlagService + ILeaseStore through a real DI scope, matching how the worker
-        // resolves them at runtime via IServiceScopeFactory. ISegmentService is also registered
-        // (always present in the real app); these flag-only tests seed no pending segments, so the
-        // coordinator's segment loop is a no-op.
+        // Wire the same services the worker resolves per tick through a real DI scope. There are no
+        // pending flags in these tests, so IFeatureFlagService is a real (empty) service. The
+        // segment publish is spied via the fake ISegmentMessageService.
         var services = new ServiceCollection();
-        services.AddTransient<IFeatureFlagService>(_ => _flagService);
+        services.AddTransient<IFeatureFlagService>(_ => new FeatureFlagService(_mongoDb));
+        services.AddTransient<ISegmentService>(_ => _segmentService);
         services.AddTransient<ILeaseStore>(_ => _leaseStore);
-        services.AddTransient<ISegmentService>(_ => new SegmentService(_mongoDb, NullLogger<SegmentService>.Instance));
+        services.AddTransient<ISegmentMessageService>(_ => segmentMessages);
+        services.AddTransient<IFeatureFlagAppService>(_ => new ThrowingFeatureFlagAppService());
         var provider = services.BuildServiceProvider();
 
         var configuration = new ConfigurationBuilder()
@@ -185,7 +186,7 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         return new CommitCoordinatorWorker(
             provider.GetRequiredService<IServiceScopeFactory>(),
             _composite,
-            producer,
+            new SpyMessageProducer(),
             configuration,
             logger ?? NullLogger<CommitCoordinatorWorker>.Instance);
     }
@@ -195,194 +196,189 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
     [Fact]
     public async Task NoCommit_When_OnlyOneOfTwoLiveDcs_HasStaged()
     {
-        const string key = "only-one-dc-staged";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
+        const string key = "seg-only-one-dc-staged";
+        var v = await SeedCommittedV1PendingV2(key);
+        var segment = await _segmentService.GetAsync(await PendingId(key));
 
-        // both DCs are live
         var now = DateTimeOffset.UtcNow;
         await UpsertLeaseAsync(DcA, now.AddMinutes(5));
         await UpsertLeaseAsync(DcB, now.AddMinutes(5));
 
         // only dc-a (db 0) has v2 staged
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, v);
 
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy);
 
         var committed = await sut.RunOnceAsync();
 
         Assert.Equal(0, committed);
-        Assert.Empty(producer.Published);
+        Assert.Empty(spy.Published);
 
         // committed read still returns the OLD value; pending intact
-        var read = await _flagService.GetCommittedAsync(_envId, key);
-        Assert.False(read.IsEnabled);
+        var read = await _segmentService.GetCommittedAsync(segment.Id);
         Assert.Equal(1, read.CommittedVersion);
+        Assert.Equal(new[] { "alice" }, read.Included);
 
-        var raw = await _flagService.GetAsync(_envId, key);
+        var raw = await _segmentService.GetAsync(segment.Id);
         Assert.NotNull(raw.Pending);
         Assert.Equal(v, raw.Pending!.Version);
 
         // dc-b committed pointer never advanced
-        Assert.False(await _dcbCache.HasStagedFlagAsync(flag.Id, v));
+        Assert.False(await _dcbCache.HasStagedSegmentAsync(segment.Id, v));
     }
 
     [Fact]
     public async Task Commits_When_AllLiveDcs_HaveStaged()
     {
-        const string key = "all-dcs-staged";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
+        const string key = "seg-all-dcs-staged";
+        var v = await SeedCommittedV1PendingV2(key);
+        var segment = await _segmentService.GetAsync(await PendingId(key));
 
         var now = DateTimeOffset.UtcNow;
         await UpsertLeaseAsync(DcA, now.AddMinutes(5));
         await UpsertLeaseAsync(DcB, now.AddMinutes(5));
 
         // both DCs have v2 staged
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
-        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, v);
+        await _dcbCache.StageSegmentAsync(segment.Pending!.Value, v);
 
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy);
 
         var committed = await sut.RunOnceAsync();
 
         Assert.Equal(1, committed);
 
         // committed read now returns the NEW value + advanced version
-        var read = await _flagService.GetCommittedAsync(_envId, key);
-        Assert.True(read.IsEnabled);
+        var read = await _segmentService.GetCommittedAsync(segment.Id);
         Assert.Equal(v, read.CommittedVersion);
+        Assert.Equal(new[] { "bob" }, read.Included);
 
         // pending slot cleared
-        var raw = await _flagService.GetAsync(_envId, key);
+        var raw = await _segmentService.GetAsync(segment.Id);
         Assert.Null(raw.Pending);
 
         // committed pointer advanced in BOTH DCs (broadcast)
-        var dcaPointer = await _mux.GetDatabase(0).StringGetAsync(RedisCaches.FlagCommittedPointer(flag.Id));
-        var dcbPointer = await _mux.GetDatabase(1).StringGetAsync(RedisCaches.FlagCommittedPointer(flag.Id));
+        var dcaPointer = await _mux.GetDatabase(0).StringGetAsync(RedisCaches.SegmentCommittedPointer(segment.Id));
+        var dcbPointer = await _mux.GetDatabase(1).StringGetAsync(RedisCaches.SegmentCommittedPointer(segment.Id));
         Assert.Equal(v, (long)dcaPointer);
         Assert.Equal(v, (long)dcbPointer);
 
-        // published to the evaluation-server topic with the new committed value
-        var publish = Assert.Single(producer.Published);
-        Assert.Equal(Topics.FeatureFlagChange, publish.Topic);
-        var publishedFlag = Assert.IsType<FeatureFlag>(publish.Message);
-        Assert.True(publishedFlag.IsEnabled);
-        Assert.Equal(flag.Id, publishedFlag.Id);
+        // segment change published for the segment's single env (env-specific -> [EnvId])
+        var publish = Assert.Single(spy.Published);
+        Assert.Equal(_envId, publish.EnvId);
+        Assert.Equal(segment.Id, publish.Segment.Id);
+        Assert.Equal(new[] { "bob" }, publish.Segment.Included);
     }
 
     [Fact]
     public async Task Commits_Ignoring_ExpiredDc_When_OnlyLiveDc_HasStaged()
     {
-        const string key = "expired-dc-ignored";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
+        const string key = "seg-expired-dc-ignored";
+        var v = await SeedCommittedV1PendingV2(key);
+        var segment = await _segmentService.GetAsync(await PendingId(key));
 
         var now = DateTimeOffset.UtcNow;
         await UpsertLeaseAsync(DcA, now.AddMinutes(5));   // dc-a live
         await UpsertLeaseAsync(DcB, now.AddMinutes(-5));  // dc-b lease EXPIRED
 
-        // only the live DC (dc-a) has v2 staged; dc-b never got it (but it's dead anyway)
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        // only the live DC (dc-a) has v2 staged
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, v);
 
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy);
 
         var committed = await sut.RunOnceAsync();
 
         Assert.Equal(1, committed);
 
-        var read = await _flagService.GetCommittedAsync(_envId, key);
-        Assert.True(read.IsEnabled);
+        var read = await _segmentService.GetCommittedAsync(segment.Id);
         Assert.Equal(v, read.CommittedVersion);
-
-        Assert.Single(producer.Published);
+        Assert.Single(spy.Published);
     }
 
     [Fact]
     public async Task Skips_When_PendingVersion_NotNewerThanCommitted()
     {
         // committed v5, pending staged at v2 (stale) -> must be skipped on monotonicity (#34)
-        const string key = "stale-pending";
-        var committed = CreateFlag(key, isEnabled: true);
+        const string key = "seg-stale-pending";
+        var committed = CreateSegment(key, "alice");
         committed.CommittedVersion = 5;
-        await _flagService.AddOneAsync(committed);
+        await _segmentService.AddOneAsync(committed);
 
-        var pendingValue = CreateFlag(key, isEnabled: false);
+        var pendingValue = CreateSegment(key, "bob");
         pendingValue.Id = committed.Id;
-        await _flagService.SetPendingAsync(_envId, key, pendingValue, version: 2);
-        var flag = await _flagService.GetAsync(_envId, key);
+        pendingValue.UpdatedAt = DateTimeOffset.FromUnixTimeMilliseconds(2).UtcDateTime;
+        await _segmentService.SetPendingAsync(committed.Id, pendingValue, version: 2);
 
         var now = DateTimeOffset.UtcNow;
         await UpsertLeaseAsync(DcA, now.AddMinutes(5));
         await UpsertLeaseAsync(DcB, now.AddMinutes(5));
 
         // even if both DCs have it staged, the stale version must not be committed
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, 2);
-        await _dcbCache.StageFlagAsync(flag.Pending!.Value, 2);
+        await _dcaCache.StageSegmentAsync(pendingValue, 2);
+        await _dcbCache.StageSegmentAsync(pendingValue, 2);
 
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy);
 
         var committed2 = await sut.RunOnceAsync();
 
         Assert.Equal(0, committed2);
-        Assert.Empty(producer.Published);
+        Assert.Empty(spy.Published);
 
-        var read = await _flagService.GetCommittedAsync(_envId, key);
-        Assert.True(read.IsEnabled);
+        var read = await _segmentService.GetCommittedAsync(committed.Id);
         Assert.Equal(5, read.CommittedVersion);
+        Assert.Equal(new[] { "alice" }, read.Included);
     }
 
     [Fact]
     public async Task NoCommit_When_NoLiveDcs()
     {
-        const string key = "no-live-dcs";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
+        const string key = "seg-no-live-dcs";
+        var v = await SeedCommittedV1PendingV2(key);
+        var segment = await _segmentService.GetAsync(await PendingId(key));
 
         // both DCs have it staged, but NO live leases exist
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
-        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, v);
+        await _dcbCache.StageSegmentAsync(segment.Pending!.Value, v);
 
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy);
 
         var committed = await sut.RunOnceAsync();
 
         Assert.Equal(0, committed);
-        Assert.Empty(producer.Published);
+        Assert.Empty(spy.Published);
 
-        var read = await _flagService.GetCommittedAsync(_envId, key);
-        Assert.False(read.IsEnabled);
+        var read = await _segmentService.GetCommittedAsync(segment.Id);
         Assert.Equal(1, read.CommittedVersion);
     }
 
     [Fact]
     public async Task SecondTick_IsIdempotent_AfterCommit()
     {
-        const string key = "idempotent";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
+        const string key = "seg-idempotent";
+        var v = await SeedCommittedV1PendingV2(key);
+        var segment = await _segmentService.GetAsync(await PendingId(key));
 
         var now = DateTimeOffset.UtcNow;
         await UpsertLeaseAsync(DcA, now.AddMinutes(5));
         await UpsertLeaseAsync(DcB, now.AddMinutes(5));
 
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
-        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, v);
+        await _dcbCache.StageSegmentAsync(segment.Pending!.Value, v);
 
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy);
 
         var first = await sut.RunOnceAsync();
         var second = await sut.RunOnceAsync();
 
         Assert.Equal(1, first);
         Assert.Equal(0, second); // nothing left pending -> no-op
-        Assert.Single(producer.Published);
+        Assert.Single(spy.Published);
     }
 
     // ----- eviction observability (#16) -----
@@ -390,28 +386,24 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
     [Fact]
     public async Task EvictedCommit_Logs_And_IncrementsCounter_NamingEvictedDc()
     {
-        // dc-a live + staged; dc-b is CONFIGURED (composite probes it) but its lease has EXPIRED, so
-        // it is evicted from the live set. The commit proceeds on the live set, and the eviction
-        // must be recorded (warning log naming dc-b + counter increment tagged dc_id=dc-b).
-        const string key = "evicted-commit-observed";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
+        const string key = "seg-evicted-commit-observed";
+        var v = await SeedCommittedV1PendingV2(key);
+        var segment = await _segmentService.GetAsync(await PendingId(key));
 
         var now = DateTimeOffset.UtcNow;
         await UpsertLeaseAsync(DcA, now.AddMinutes(5));   // dc-a live
         await UpsertLeaseAsync(DcB, now.AddMinutes(-5));  // dc-b lease EXPIRED -> evicted
 
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, v);
 
         var logger = new CapturingLogger();
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer, logger);
+        var spy = new SpySegmentMessageService();
+        var sut = CreateSut(spy, logger);
 
         using var counter = new CounterCollector(CommitCoordinatorWorker.EvictedCommitCounterName);
 
         var committed = await sut.RunOnceAsync();
 
-        // commit decision unchanged: it still committed on the live set
         Assert.Equal(1, committed);
 
         // metric: exactly one increment, tagged with the evicted dc_id
@@ -419,48 +411,56 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         Assert.Equal(1, measurement.Value);
         Assert.Equal(DcB, measurement.Tags["dc_id"]);
 
-        // log: a warning naming the flag, the version, and the evicted DC
+        // log: a warning naming the segment, the version, and the evicted DC
         var warning = Assert.Single(logger.Warnings);
-        Assert.Contains(flag.Id.ToString(), warning);
+        Assert.Contains(segment.Id.ToString(), warning);
         Assert.Contains(v.ToString(), warning);
         Assert.Contains(DcB, warning);
     }
 
-    [Fact]
-    public async Task NoEviction_When_AllConfiguredDcsLive_DoesNotLogOrIncrement()
+    // ----- helpers -----
+
+    /// <summary>Resolves the seeded segment's Id by its key (single env-specific segment per test).</summary>
+    private async Task<Guid> PendingId(string key)
     {
-        // both configured DCs are live + staged -> no eviction; no extra warning, no counter.
-        const string key = "no-eviction-observed";
-        var (_, _, v) = await SeedCommittedV1PendingV2(key);
-        var flag = await _flagService.GetAsync(_envId, key);
-
-        var now = DateTimeOffset.UtcNow;
-        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
-        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
-
-        await _dcaCache.StageFlagAsync(flag.Pending!.Value, v);
-        await _dcbCache.StageFlagAsync(flag.Pending!.Value, v);
-
-        var logger = new CapturingLogger();
-        var producer = new SpyMessageProducer();
-        var sut = CreateSut(producer, logger);
-
-        using var counter = new CounterCollector(CommitCoordinatorWorker.EvictedCommitCounterName);
-
-        var committed = await sut.RunOnceAsync();
-
-        Assert.Equal(1, committed);
-        Assert.Empty(counter.Measurements);
-        Assert.Empty(logger.Warnings);
+        var pending = await _segmentService.GetPendingAsync();
+        return pending.First(s => s.Key == key).Id;
     }
 
     // ----- test doubles -----
 
+    private sealed class SpySegmentMessageService : ISegmentMessageService
+    {
+        public List<(Guid EnvId, ICollection<FlagReference> AffectedFlags, Segment Segment)> Published { get; } = new();
+
+        public ValueTask<ICollection<FlagReference>> GetAffectedFlagsAsync(Guid envId, OnSegmentChange notification)
+        {
+            // No related flags are seeded in these tests, so there are no affected flags to compute.
+            // Returning empty keeps OnSegmentUpdatedAsync (the throwing app service) from being hit.
+            return ValueTask.FromResult<ICollection<FlagReference>>([]);
+        }
+
+        public Task PublishSegmentChangeMessage(Guid envId, ICollection<FlagReference> affectedFlags, Segment segment)
+        {
+            Published.Add((envId, affectedFlags, segment));
+            return Task.CompletedTask;
+        }
+    }
+
     /// <summary>
-    /// Captures emitted measurements for a single named counter on the control-plane consistency
-    /// meter via <see cref="MeterListener"/>, so the test can assert the eviction counter fired
-    /// with the expected value + tags.
+    /// Guard: with no affected flags, OnSegmentUpdatedAsync must never be called. If the coordinator
+    /// ever calls it (a regression), the test fails loudly instead of silently passing.
     /// </summary>
+    private sealed class ThrowingFeatureFlagAppService : IFeatureFlagAppService
+    {
+        public Task ApplyDraftAsync(Guid draftId, string operation, Guid operatorId) =>
+            throw new InvalidOperationException("ApplyDraftAsync should not be called by the commit coordinator.");
+
+        public Task OnSegmentUpdatedAsync(Segment segment, Guid operatorId, ICollection<FlagReference> flagReferences) =>
+            throw new InvalidOperationException(
+                "OnSegmentUpdatedAsync should not be called when there are no affected flags.");
+    }
+
     private sealed class CounterCollector : IDisposable
     {
         private readonly MeterListener _listener;
@@ -498,7 +498,6 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
         public void Dispose() => _listener.Dispose();
     }
 
-    /// <summary>Captures warning-level log messages (rendered) for assertion.</summary>
     private sealed class CapturingLogger : ILogger<CommitCoordinatorWorker>
     {
         public List<string> Warnings { get; } = new();
@@ -529,13 +528,8 @@ public sealed class CommitCoordinatorWorkerTests : IAsyncLifetime
 
     private sealed class SpyMessageProducer : IMessageProducer
     {
-        public List<(string Topic, object Message)> Published { get; } = new();
-
-        public Task PublishAsync<TMessage>(string topic, TMessage message) where TMessage : class
-        {
-            Published.Add((topic, message));
-            return Task.CompletedTask;
-        }
+        public Task PublishAsync<TMessage>(string topic, TMessage message) where TMessage : class =>
+            Task.CompletedTask;
     }
 
     private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient


### PR DESCRIPTION
Closes **#17 (C5)** — the segment path now matches the flag path end-to-end (S1 model → S2 stage/handler → S3 commit).

`CommitCoordinatorWorker.RunOnceAsync` gains a segment loop mirroring the flag loop: `ISegmentService.GetPendingAsync()` → skip `V <= CommittedVersion` → `GetStagedSegmentDcsAsync` probe → when all live DCs staged: `CommitSegmentAsync(envIds, …)` + version-guarded `PromotePendingAsync(id, V)`, then replays the affected-flags propagation S2 deferred (per-env `GetAffectedFlagsAsync` → `OnSegmentUpdatedAsync` → `PublishSegmentChangeMessage`). Reconstructs an `Operations.Update` notification from the committed segment (`OperatorId = Guid.Empty` at commit time). Same evicted-commit metric/log as flags. Flag loop unchanged; worker still no-ops unless GatedCommit.

**Verification (real Mongo + Redis :6389):** 7 new segment-coordinator tests (one-DC=no-commit, both=commit+promote+publish-per-env, stale-skip, expired-DC ignored, no-live-DCs, idempotent, eviction); full CP integration 19/19; CP unit 52/52; back-end + control-plane builds clean.

**Known follow-up:** segment recovery (returning-DC backfill of segments) — the segment analog of E1 — is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)