### PR TITLE
✨ Consistency metrics for the commit coordinator (F1)

### DIFF
--- a/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/CommitCoordinatorWorker.cs
@@ -69,6 +69,27 @@ public sealed class CommitCoordinatorWorker : BackgroundService
     /// </summary>
     public const string EvictedCommitCounterName = "control_plane.consistency.evicted_commits";
 
+    /// <summary>
+    /// F1 (#24): counter incremented once per successful commit (flag OR segment). Tagged
+    /// <c>resource_type</c> = <c>flag</c> | <c>segment</c> (and <c>env_id</c> on the flag path, cheaply
+    /// available from the pending flag record).
+    /// </summary>
+    public const string CommitsCounterName = "control_plane.consistency.commits";
+
+    /// <summary>
+    /// F1 (#24): histogram of the stage-to-commit latency in milliseconds, recorded at each commit as
+    /// <c>now - resourceUpdatedAt</c> (the resource's <c>UpdatedAt</c> is the staged version's
+    /// timestamp, so this approximates stage->commit latency). Tagged <c>resource_type</c>.
+    /// </summary>
+    public const string TimeToCommitHistogramName = "control_plane.consistency.time_to_commit_ms";
+
+    /// <summary>
+    /// F1 (#24): observable gauge reporting the count of currently-pending (staged-but-not-committed)
+    /// items per <c>resource_type</c> = <c>flag</c> | <c>segment</c>. Backed by fields refreshed at the
+    /// end of each <see cref="RunOnceAsync"/> from the latest <c>GetPendingAsync</c> reads.
+    /// </summary>
+    public const string PendingBacklogGaugeName = "control_plane.consistency.pending_backlog";
+
     private static readonly Meter Meter = new(MeterName);
 
     private static readonly Counter<long> EvictedCommitCounter = Meter.CreateCounter<long>(
@@ -76,6 +97,62 @@ public sealed class CommitCoordinatorWorker : BackgroundService
         unit: "{commit}",
         description:
         "Number of flag-version commits made while a configured DC was evicted (absent from the live set).");
+
+    private static readonly Counter<long> CommitsCounter = Meter.CreateCounter<long>(
+        CommitsCounterName,
+        unit: "{commit}",
+        description: "Number of successful commits, tagged by resource_type (flag | segment).");
+
+    private static readonly Histogram<double> TimeToCommitHistogram = Meter.CreateHistogram<double>(
+        TimeToCommitHistogramName,
+        unit: "ms",
+        description:
+        "Stage-to-commit latency (now - resource UpdatedAt) in milliseconds, tagged by resource_type.");
+
+    // Observable backlog gauge: reports the most recent pending counts captured at the end of a tick.
+    // Static so a single registration on the shared Meter survives across worker instances (matching
+    // the rest of the static instruments above). Volatile because the gauge callback may be invoked
+    // by the metrics infra on a different thread than the tick that updates the fields.
+    private static volatile int _pendingFlagBacklog;
+    private static volatile int _pendingSegmentBacklog;
+
+    // NOTE (#46): per-DC "applied watermark / lag" metrics are intentionally NOT emitted here. They
+    // depend on the eval-server's applied-watermark, whose source is still inaccurate (tracked in
+    // #46); adding them now would publish misleading data. Revisit once #46 lands.
+    private static readonly ObservableGauge<long> PendingBacklogGauge = Meter.CreateObservableGauge(
+        PendingBacklogGaugeName,
+        ObservePendingBacklog,
+        unit: "{item}",
+        description: "Currently-pending (staged-but-not-committed) item count per resource_type.");
+
+    private static IEnumerable<Measurement<long>> ObservePendingBacklog()
+    {
+        yield return new Measurement<long>(
+            _pendingFlagBacklog,
+            new KeyValuePair<string, object?>("resource_type", "flag"));
+        yield return new Measurement<long>(
+            _pendingSegmentBacklog,
+            new KeyValuePair<string, object?>("resource_type", "segment"));
+    }
+
+    /// <summary>
+    /// F1 (#24): record a stage-to-commit latency sample. <paramref name="resourceUpdatedAt"/> is the
+    /// staged value's <c>UpdatedAt</c> (the staged version's timestamp), so <c>now - UpdatedAt</c>
+    /// approximates stage->commit latency. Clamped at 0 to avoid a negative sample from clock skew.
+    /// </summary>
+    private static void RecordTimeToCommit(string resourceType, DateTime resourceUpdatedAt)
+    {
+        var updatedAtUtc = DateTime.SpecifyKind(resourceUpdatedAt, DateTimeKind.Utc);
+        var elapsedMs = (DateTime.UtcNow - updatedAtUtc).TotalMilliseconds;
+        if (elapsedMs < 0)
+        {
+            elapsedMs = 0;
+        }
+
+        TimeToCommitHistogram.Record(
+            elapsedMs,
+            new KeyValuePair<string, object?>("resource_type", resourceType));
+    }
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICacheService _compositeCache;
@@ -162,6 +239,12 @@ public sealed class CommitCoordinatorWorker : BackgroundService
             .GetRequiredService<ISegmentService>()
             .GetPendingAsync();
 
+        // F1 (#24): refresh the observable pending-backlog gauge from this tick's GetPendingAsync
+        // counts. Done up front so EVERY return path (including the no-pending and no-live-DC early
+        // returns below) reports the current backlog. Side-effect-only; does not affect commits.
+        _pendingFlagBacklog = pending.Count;
+        _pendingSegmentBacklog = pendingSegments.Count;
+
         if (pending.Count == 0 && pendingSegments.Count == 0)
         {
             return 0;
@@ -240,6 +323,15 @@ public sealed class CommitCoordinatorWorker : BackgroundService
             // IS the new committed state; it carries the same shape the BestEffort path publishes.
             await _messageProducer.PublishAsync(Topics.FeatureFlagChange, pendingChange.Value);
             count++;
+
+            // F1 (#24): consistency metrics. Side-effect-only — must not change commit behavior.
+            // One commit increment (tagged resource_type=flag + env_id) and one stage->commit latency
+            // sample (now - the staged value's UpdatedAt).
+            CommitsCounter.Add(
+                1,
+                new KeyValuePair<string, object?>("resource_type", "flag"),
+                new KeyValuePair<string, object?>("env_id", flag.EnvId.ToString()));
+            RecordTimeToCommit("flag", pendingChange.Value.UpdatedAt);
 
             // Observability (#16): the commit decision above is intentionally made on the LIVE set
             // (committing without a down DC is the design). Record — for operators — any CONFIGURED
@@ -354,6 +446,14 @@ public sealed class CommitCoordinatorWorker : BackgroundService
                 }
 
                 count++;
+
+                // F1 (#24): consistency metrics, mirroring the flag path. Side-effect-only. One commit
+                // increment (tagged resource_type=segment) and one stage->commit latency sample (now -
+                // the staged value's UpdatedAt, whose unix-ms equals the staged version).
+                CommitsCounter.Add(
+                    1,
+                    new KeyValuePair<string, object?>("resource_type", "segment"));
+                RecordTimeToCommit("segment", pendingChange.Value.UpdatedAt);
 
                 // Observability (#16): mirror the flag path — record any CONFIGURED DC that was
                 // evicted (present in the probed staged map's keys but absent from the live set).

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/ConsistencyMetricsTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/ConsistencyMetricsTests.cs
@@ -1,0 +1,483 @@
+using Api.Application.ControlPlane;
+using Api.Infrastructure.Caches;
+using Application.Caches;
+using Application.ControlPlane;
+using Application.Segments;
+using Application.Services;
+using Domain.ControlPlane;
+using Domain.FeatureFlags;
+using Domain.Messages;
+using Domain.Segments;
+using Infrastructure.Caches.Redis;
+using Infrastructure.Persistence.MongoDb;
+using Infrastructure.Services.MongoDb;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using StackExchange.Redis;
+
+namespace Api.IntegrationTests.ControlPlane;
+
+/// <summary>
+/// F1 (#24) consistency-metrics acceptance tests for <see cref="CommitCoordinatorWorker"/>. Exercises
+/// the three F1 instruments (all on the existing <see cref="CommitCoordinatorWorker.MeterName"/>
+/// meter) end-to-end against real infrastructure, reusing the C3b-2 coordinator harness (real Mongo +
+/// real Redis whose two logical DB indexes simulate two DCs):
+///   1. <see cref="CommitCoordinatorWorker.CommitsCounterName"/> — once per committed flag/segment,
+///      tagged <c>resource_type</c>.
+///   2. <see cref="CommitCoordinatorWorker.TimeToCommitHistogramName"/> — stage->commit latency in
+///      ms recorded at each commit, tagged <c>resource_type</c>.
+///   3. <see cref="CommitCoordinatorWorker.PendingBacklogGaugeName"/> — observable gauge reporting the
+///      currently-pending count per <c>resource_type</c>, updated at the end of each tick.
+///
+/// Requires:
+///  - MongoDB at mongodb://admin:password@localhost:27017 (unique throwaway DB, dropped on dispose).
+///  - Redis on port 6390 (override via F1_REDIS): two logical DB indexes simulate two DCs
+///    (dc-a = db 0, dc-b = db 1).
+///      docker run -d --rm -p 6390:6379 --name f1-redis redis:7-alpine
+/// Fails loudly (not silently skips) if either is unreachable.
+/// </summary>
+public sealed class ConsistencyMetricsTests : IAsyncLifetime
+{
+    private const string MongoConnectionString = "mongodb://admin:password@localhost:27017/?authSource=admin";
+    private const string DefaultRedis = "localhost:6390";
+
+    private const string DcA = "dc-a";
+    private const string DcB = "dc-b";
+
+    private readonly string _dbName = $"featbit_f1_test_{Guid.NewGuid():N}";
+    private readonly Guid _envId = Guid.NewGuid();
+
+    private MongoDbClient _mongoDb = null!;
+    private FeatureFlagService _flagService = null!;
+    private SegmentService _segmentService = null!;
+    private MongoLeaseStore _leaseStore = null!;
+
+    private ConnectionMultiplexer _mux = null!;
+    private RedisCacheService _dcaCache = null!; // db 0
+    private RedisCacheService _dcbCache = null!; // db 1
+    private CompositeRedisCacheService _composite = null!;
+
+    private static string RedisConnectionString =>
+        Environment.GetEnvironmentVariable("F1_REDIS") ?? DefaultRedis;
+
+    public async Task InitializeAsync()
+    {
+        // ---- Mongo ----
+        var options = Options.Create(new MongoDbOptions
+        {
+            ConnectionString = MongoConnectionString,
+            Database = _dbName
+        });
+        _mongoDb = new MongoDbClient(options);
+        await _mongoDb.Database.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1));
+
+        _flagService = new FeatureFlagService(_mongoDb);
+        _segmentService = new SegmentService(_mongoDb, NullLogger<SegmentService>.Instance);
+        _leaseStore = new MongoLeaseStore(_mongoDb);
+
+        // ---- Redis (two DB indexes = two DCs) ----
+        var redisOptions = ConfigurationOptions.Parse(RedisConnectionString);
+        redisOptions.AbortOnConnectFail = false;
+        redisOptions.ConnectTimeout = 2000;
+
+        _mux = await ConnectionMultiplexer.ConnectAsync(redisOptions);
+        if (!_mux.IsConnected)
+        {
+            throw new InvalidOperationException(
+                $"No Redis reachable at '{RedisConnectionString}'. Start one with: " +
+                "docker run -d --rm -p 6390:6379 --name f1-redis redis:7-alpine " +
+                "(or set the F1_REDIS env var).");
+        }
+
+        _dcaCache = new RedisCacheService(new TestRedisClient(_mux, db: 0));
+        _dcbCache = new RedisCacheService(new TestRedisClient(_mux, db: 1));
+
+        _composite = new CompositeRedisCacheService(
+            new[]
+            {
+                new DcCacheService(DcA, _dcaCache),
+                new DcCacheService(DcB, _dcbCache)
+            },
+            NullLogger<CompositeRedisCacheService>.Instance);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _mux.GetDatabase(0).ExecuteAsync("FLUSHDB");
+        await _mux.GetDatabase(1).ExecuteAsync("FLUSHDB");
+        _mux.Dispose();
+
+        await _mongoDb.Database.Client.DropDatabaseAsync(_dbName);
+    }
+
+    // ----- helpers -----
+
+    private FeatureFlag CreateFlag(string key, bool isEnabled)
+    {
+        var enabledVariationId = Guid.NewGuid().ToString();
+        var disabledVariationId = Guid.NewGuid().ToString();
+
+        var variations = new List<Variation>
+        {
+            new() { Id = enabledVariationId, Name = "true", Value = "true" },
+            new() { Id = disabledVariationId, Name = "false", Value = "false" }
+        };
+
+        return new FeatureFlag(
+            envId: _envId,
+            name: key,
+            description: string.Empty,
+            key: key,
+            isEnabled: isEnabled,
+            variationType: "boolean",
+            variations: variations,
+            disabledVariationId: disabledVariationId,
+            enabledVariationId: enabledVariationId,
+            tags: [],
+            currentUserId: Guid.NewGuid()
+        );
+    }
+
+    /// <summary>
+    /// Seeds a committed flag (v1, disabled) with a staged pending change. The pending value's
+    /// <c>UpdatedAt</c> is set to <paramref name="updatedAt"/> so the histogram can assert a known
+    /// stage->commit latency (now - UpdatedAt). Returns the pending version.
+    /// </summary>
+    private async Task<long> SeedFlagCommittedV1PendingV2(string key, DateTime updatedAt)
+    {
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _flagService.AddOneAsync(committed);
+
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        pendingValue.Id = committed.Id;
+        pendingValue.UpdatedAt = updatedAt;
+        const long pendingVersion = 2;
+        await _flagService.SetPendingAsync(_envId, key, pendingValue, pendingVersion);
+
+        return pendingVersion;
+    }
+
+    private Segment CreateSegment(string key, params string[] included)
+    {
+        return new Segment(
+            workspaceId: Guid.NewGuid(),
+            envId: _envId,
+            name: key,
+            key: key,
+            type: SegmentType.EnvironmentSpecific,
+            scopes: [],
+            included: included,
+            excluded: [],
+            rules: [],
+            description: string.Empty);
+    }
+
+    /// <summary>
+    /// Seeds a committed segment (v1) with a staged pending change. The pending value's
+    /// <c>UpdatedAt</c> is set to <paramref name="updatedAt"/> (its unix-ms == pending version, matching
+    /// how S2 stages). Returns the pending version.
+    /// </summary>
+    private async Task<long> SeedSegmentCommittedV1Pending(string key, DateTime updatedAt)
+    {
+        var committed = CreateSegment(key, "alice");
+        committed.CommittedVersion = 1;
+        await _segmentService.AddOneAsync(committed);
+
+        var pendingVersion = new DateTimeOffset(updatedAt).ToUnixTimeMilliseconds();
+
+        var pendingValue = CreateSegment(key, "bob");
+        pendingValue.Id = committed.Id;
+        pendingValue.UpdatedAt = updatedAt;
+        await _segmentService.SetPendingAsync(committed.Id, pendingValue, pendingVersion);
+
+        return pendingVersion;
+    }
+
+    private async Task UpsertLeaseAsync(string dcId, DateTimeOffset expiresAt)
+    {
+        await _leaseStore.UpsertLeaseAsync(new DcLease
+        {
+            DcId = dcId,
+            Region = dcId,
+            LastHeartbeatAt = DateTimeOffset.UtcNow,
+            LeaseExpiresAt = expiresAt
+        });
+    }
+
+    private CommitCoordinatorWorker CreateSut()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IFeatureFlagService>(_ => _flagService);
+        services.AddTransient<ISegmentService>(_ => _segmentService);
+        services.AddTransient<ILeaseStore>(_ => _leaseStore);
+        services.AddTransient<ISegmentMessageService>(_ => new NoopSegmentMessageService());
+        services.AddTransient<IFeatureFlagAppService>(_ => new NoopFeatureFlagAppService());
+        var provider = services.BuildServiceProvider();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ControlPlane:ConsistencyMode"] = "GatedCommit"
+            })
+            .Build();
+
+        return new CommitCoordinatorWorker(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            _composite,
+            new SpyMessageProducer(),
+            configuration,
+            NullLogger<CommitCoordinatorWorker>.Instance);
+    }
+
+    // ----- acceptance cases -----
+
+    [Fact]
+    public async Task Commit_Increments_CommitsCounter_And_Records_TimeToCommit_PerResourceType()
+    {
+        // one flag + one segment, both staged on both live DCs -> both commit this tick.
+        var flagUpdatedAt = DateTime.UtcNow.AddSeconds(-3);
+        var flagVersion = await SeedFlagCommittedV1PendingV2("f1-flag", flagUpdatedAt);
+        var flag = await _flagService.GetAsync(_envId, "f1-flag");
+
+        var segUpdatedAt = DateTime.UtcNow.AddSeconds(-2);
+        var segVersion = await SeedSegmentCommittedV1Pending("f1-seg", segUpdatedAt);
+        var segment = (await _segmentService.GetPendingAsync()).First(s => s.Key == "f1-seg");
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, flagVersion);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, flagVersion);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, segVersion);
+        await _dcbCache.StageSegmentAsync(segment.Pending!.Value, segVersion);
+
+        using var commits = new CounterCollector(CommitCoordinatorWorker.CommitsCounterName);
+        using var histogram = new HistogramCollector(CommitCoordinatorWorker.TimeToCommitHistogramName);
+
+        var sut = CreateSut();
+        var committed = await sut.RunOnceAsync();
+
+        Assert.Equal(2, committed);
+
+        // commits counter: exactly one flag + one segment increment, tagged resource_type
+        Assert.Equal(2, commits.Measurements.Count);
+        var flagCommit = Assert.Single(commits.Measurements, m => (string?)m.Tags["resource_type"] == "flag");
+        Assert.Equal(1, flagCommit.Value);
+        var segCommit = Assert.Single(commits.Measurements, m => (string?)m.Tags["resource_type"] == "segment");
+        Assert.Equal(1, segCommit.Value);
+
+        // env_id tag present on the flag commit (cheap to add from the pending flag record)
+        Assert.Equal(_envId.ToString(), (string?)flagCommit.Tags["env_id"]);
+
+        // time-to-commit histogram: one measurement per resource_type, each a positive ms latency
+        Assert.Equal(2, histogram.Measurements.Count);
+        var flagLatency = Assert.Single(histogram.Measurements, m => (string?)m.Tags["resource_type"] == "flag");
+        var segLatency = Assert.Single(histogram.Measurements, m => (string?)m.Tags["resource_type"] == "segment");
+        // UpdatedAt was ~3s/~2s ago, so latency should be at least ~1s of ms (sanity, not flaky-tight)
+        Assert.True(flagLatency.Value >= 1000, $"flag latency was {flagLatency.Value}");
+        Assert.True(segLatency.Value >= 1000, $"segment latency was {segLatency.Value}");
+    }
+
+    [Fact]
+    public async Task PendingBacklog_Gauge_Reports_RemainingPendingCounts_PerResourceType()
+    {
+        // 2 pending flags + 1 pending segment, but NOTHING staged -> nothing commits, so after the
+        // tick the backlog gauge reports the full pending counts (flag=2, segment=1).
+        await SeedFlagCommittedV1PendingV2("f1-backlog-flag-a", DateTime.UtcNow);
+        await SeedFlagCommittedV1PendingV2("f1-backlog-flag-b", DateTime.UtcNow);
+        await SeedSegmentCommittedV1Pending("f1-backlog-seg", DateTime.UtcNow.AddSeconds(-1));
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var sut = CreateSut();
+        var committed = await sut.RunOnceAsync(); // nothing staged -> 0 committed
+        Assert.Equal(0, committed);
+
+        // observable gauge is read on demand: force a flush and capture the reported values
+        var backlog = ReadBacklogGauge();
+        Assert.Equal(2, backlog["flag"]);
+        Assert.Equal(1, backlog["segment"]);
+    }
+
+    [Fact]
+    public async Task PendingBacklog_Gauge_Reports_Zero_AfterBacklogDrained()
+    {
+        // one flag + one segment staged on both DCs -> both commit on tick 1. A second tick finds an
+        // empty pending set, so the backlog gauge must report 0 for both resource types.
+        var flagVersion = await SeedFlagCommittedV1PendingV2("f1-drain-flag", DateTime.UtcNow.AddSeconds(-1));
+        var flag = await _flagService.GetAsync(_envId, "f1-drain-flag");
+
+        var segVersion = await SeedSegmentCommittedV1Pending("f1-drain-seg", DateTime.UtcNow.AddSeconds(-1));
+        var segment = (await _segmentService.GetPendingAsync()).First(s => s.Key == "f1-drain-seg");
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        await _dcaCache.StageFlagAsync(flag.Pending!.Value, flagVersion);
+        await _dcbCache.StageFlagAsync(flag.Pending!.Value, flagVersion);
+        await _dcaCache.StageSegmentAsync(segment.Pending!.Value, segVersion);
+        await _dcbCache.StageSegmentAsync(segment.Pending!.Value, segVersion);
+
+        var sut = CreateSut();
+        Assert.Equal(2, await sut.RunOnceAsync()); // commit both
+        Assert.Equal(0, await sut.RunOnceAsync()); // nothing left pending
+
+        var backlog = ReadBacklogGauge();
+        Assert.Equal(0, backlog["flag"]);
+        Assert.Equal(0, backlog["segment"]);
+    }
+
+    /// <summary>
+    /// Force a single read of the observable backlog gauge and return the latest value per
+    /// <c>resource_type</c>. Uses a short-lived <see cref="MeterListener"/> with
+    /// <c>RecordObservableInstruments</c> to pull the current measurements on demand.
+    /// </summary>
+    private static Dictionary<string, long> ReadBacklogGauge()
+    {
+        var values = new Dictionary<string, long>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == CommitCoordinatorWorker.MeterName
+                    && instrument.Name == CommitCoordinatorWorker.PendingBacklogGaugeName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "resource_type" && tag.Value is string rt)
+                {
+                    values[rt] = measurement;
+                }
+            }
+        });
+
+        listener.Start();
+        listener.RecordObservableInstruments();
+
+        return values;
+    }
+
+    // ----- test doubles -----
+
+    private sealed class NoopSegmentMessageService : ISegmentMessageService
+    {
+        public ValueTask<ICollection<FlagReference>> GetAffectedFlagsAsync(Guid envId, OnSegmentChange notification) =>
+            ValueTask.FromResult<ICollection<FlagReference>>([]);
+
+        public Task PublishSegmentChangeMessage(Guid envId, ICollection<FlagReference> affectedFlags, Segment segment) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class NoopFeatureFlagAppService : IFeatureFlagAppService
+    {
+        public Task ApplyDraftAsync(Guid draftId, string operation, Guid operatorId) => Task.CompletedTask;
+
+        public Task OnSegmentUpdatedAsync(Segment segment, Guid operatorId, ICollection<FlagReference> flagReferences) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class CounterCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+
+        public List<(long Value, IReadOnlyDictionary<string, object?> Tags)> Measurements { get; } = new();
+
+        public CounterCollector(string instrumentName)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == CommitCoordinatorWorker.MeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+            {
+                var dict = new Dictionary<string, object?>();
+                foreach (var tag in tags)
+                {
+                    dict[tag.Key] = tag.Value;
+                }
+
+                Measurements.Add((measurement, dict));
+            });
+
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed class HistogramCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+
+        public List<(double Value, IReadOnlyDictionary<string, object?> Tags)> Measurements { get; } = new();
+
+        public HistogramCollector(string instrumentName)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == CommitCoordinatorWorker.MeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<double>((_, measurement, tags, _) =>
+            {
+                var dict = new Dictionary<string, object?>();
+                foreach (var tag in tags)
+                {
+                    dict[tag.Key] = tag.Value;
+                }
+
+                Measurements.Add((measurement, dict));
+            });
+
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed class SpyMessageProducer : IMessageProducer
+    {
+        public Task PublishAsync<TMessage>(string topic, TMessage message) where TMessage : class =>
+            Task.CompletedTask;
+    }
+
+    private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient
+    {
+        public IConnectionMultiplexer Connection { get; } = connection;
+
+        public IDatabase GetDatabase() => Connection.GetDatabase(db);
+    }
+}


### PR DESCRIPTION
Closes #24. Extends the existing `FeatBit.ControlPlane.Consistency` meter (from C4):
- `control_plane.consistency.commits` (counter, tagged `resource_type` flag/segment, +`env_id` for flags) — one per successful commit, both loops.
- `control_plane.consistency.time_to_commit_ms` (histogram) — `now - resource.UpdatedAt` at commit (clamped ≥0, UTC-normalized), tagged `resource_type`.
- `control_plane.consistency.pending_backlog` (observable gauge) — current pending counts per `resource_type`, refreshed each tick before early-returns.

Side-effect-only (commit behavior unchanged). **Per-DC applied-watermark/lag metrics deliberately omitted** — they depend on the still-inaccurate eval-server watermark (#46); noted in-code.

**Verification (real Redis :6390 + Mongo):** 3 new metric tests via `MeterListener` (flag+segment commit increments + time-to-commit samples + backlog gauge incl. drain-to-0); full CP suite 52 unit + 22 integration; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)