### PR TITLE
🐛 Version-monotonicity guard on SetPendingAsync (#34)

### DIFF
--- a/modules/back-end/src/Application/Services/IFeatureFlagService.cs
+++ b/modules/back-end/src/Application/Services/IFeatureFlagService.cs
@@ -30,6 +30,12 @@ public interface IFeatureFlagService : IService<FeatureFlag>
     /// Stage <paramref name="pendingValue"/> as a pending change on the flag identified
     /// by <paramref name="envId"/>/<paramref name="key"/>. The committed value is left
     /// untouched, so <see cref="GetCommittedAsync"/> still returns the old value.
+    /// <para>
+    /// Monotonicity guard (#34): the stage is applied ONLY when <paramref name="version"/> is
+    /// strictly greater than both the already-staged pending version (if any) and the committed
+    /// version; otherwise it is a no-op. This prevents an out-of-order/stale stage from clobbering
+    /// a newer pending change (which the coordinator could then commit).
+    /// </para>
     /// </summary>
     Task SetPendingAsync(Guid envId, string key, FeatureFlag pendingValue, long version);
 

--- a/modules/back-end/src/Application/Services/ISegmentService.cs
+++ b/modules/back-end/src/Application/Services/ISegmentService.cs
@@ -32,6 +32,12 @@ public interface ISegmentService : IService<Segment>
     /// Stage <paramref name="pendingValue"/> as a pending change on the segment identified by
     /// <paramref name="id"/>. The committed value is left untouched, so
     /// <see cref="GetCommittedAsync"/> still returns the old value.
+    /// <para>
+    /// Monotonicity guard (#34): the stage is applied ONLY when <paramref name="version"/> is
+    /// strictly greater than both the already-staged pending version (if any) and the committed
+    /// version; otherwise it is a no-op. This prevents an out-of-order/stale stage from clobbering
+    /// a newer pending change (which the coordinator could then commit).
+    /// </para>
     /// </summary>
     Task SetPendingAsync(Guid id, Segment pendingValue, long version);
 

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/FeatureFlagService.cs
@@ -149,6 +149,22 @@ public class FeatureFlagService(AppDbContext dbContext)
         // load the committed row (left otherwise untouched)
         var flag = await GetAsync(envId, key);
 
+        // Monotonicity guard (#34): only stage this change when its version is STRICTLY GREATER
+        // than both the already-staged pending version (if any) AND the committed version. An
+        // out-of-order/stale stage carrying a lower version (but still above committed) must not
+        // clobber a newer pending — otherwise the coordinator could later commit the stale value.
+        if (version <= flag.CommittedVersion || (flag.Pending != null && version <= flag.Pending.Version))
+        {
+            // stale / out-of-order stage — leave the existing pending (or lack of one) intact
+            return;
+        }
+
+        // NOTE (#33): without a rowversion/concurrency token there is a residual non-atomic window
+        // between the GetAsync above and SaveChanges here — a racing SetPendingAsync staging a
+        // newer pending in that window could be overwritten. The in-memory version check narrows
+        // but does not close it for the EF provider; closing it requires an optimistic-concurrency
+        // token (tracked in #33). The Mongo provider closes it via a version-filtered UpdateOneAsync.
+
         // write ONLY the pending data; committed fields stay as they are
         flag.SetPending(pendingValue, version);
 

--- a/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/SegmentService.cs
+++ b/modules/back-end/src/Infrastructure/Services/EntityFrameworkCore/SegmentService.cs
@@ -202,6 +202,22 @@ public class SegmentService(AppDbContext dbContext, ILogger<SegmentService> logg
         // load the committed row (left otherwise untouched)
         var segment = await GetAsync(id);
 
+        // Monotonicity guard (#34): only stage this change when its version is STRICTLY GREATER
+        // than both the already-staged pending version (if any) AND the committed version. An
+        // out-of-order/stale stage carrying a lower version (but still above committed) must not
+        // clobber a newer pending — otherwise the coordinator could later commit the stale value.
+        if (version <= segment.CommittedVersion || (segment.Pending != null && version <= segment.Pending.Version))
+        {
+            // stale / out-of-order stage — leave the existing pending (or lack of one) intact
+            return;
+        }
+
+        // NOTE (#33): without a rowversion/concurrency token there is a residual non-atomic window
+        // between the GetAsync above and SaveChanges here — a racing SetPendingAsync staging a
+        // newer pending in that window could be overwritten. The in-memory version check narrows
+        // but does not close it for the EF provider; closing it requires an optimistic-concurrency
+        // token (tracked in #33). The Mongo provider closes it via a version-filtered UpdateOneAsync.
+
         // write ONLY the pending data; committed fields stay as they are
         segment.SetPending(pendingValue, version);
 

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
@@ -163,9 +163,21 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
             Value = pendingValue
         };
 
+        // Monotonicity guard (#34): only stage this change when its version is STRICTLY GREATER
+        // than both the already-staged pending version (if any) AND the committed version. An
+        // out-of-order/stale stage carrying a lower version (but still above committed) must not
+        // clobber a newer pending — otherwise the coordinator could later commit the stale value.
+        // The filter is evaluated server-side so the check-and-set is atomic: if a concurrent
+        // writer staged a newer pending after our existence check, the filter no longer matches
+        // and this update becomes a no-op (MatchedCount == 0).
         var filter = Builders<FeatureFlag>.Filter.And(
             Builders<FeatureFlag>.Filter.Eq(x => x.EnvId, envId),
-            Builders<FeatureFlag>.Filter.Eq(x => x.Key, key)
+            Builders<FeatureFlag>.Filter.Eq(x => x.Key, key),
+            Builders<FeatureFlag>.Filter.Lt(x => x.CommittedVersion, version),
+            Builders<FeatureFlag>.Filter.Or(
+                Builders<FeatureFlag>.Filter.Eq(x => x.Pending, null),
+                Builders<FeatureFlag>.Filter.Lt(x => x.Pending!.Version, version)
+            )
         );
         var update = Builders<FeatureFlag>.Update.Set(x => x.Pending, pending);
 

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/SegmentService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/SegmentService.cs
@@ -200,7 +200,21 @@ public class SegmentService(MongoDbClient mongoDb, ILogger<SegmentService> logge
             Value = pendingValue
         };
 
-        var filter = Builders<Segment>.Filter.Eq(x => x.Id, id);
+        // Monotonicity guard (#34): only stage this change when its version is STRICTLY GREATER
+        // than both the already-staged pending version (if any) AND the committed version. An
+        // out-of-order/stale stage carrying a lower version (but still above committed) must not
+        // clobber a newer pending — otherwise the coordinator could later commit the stale value.
+        // The filter is evaluated server-side so the check-and-set is atomic: if a concurrent
+        // writer staged a newer pending after our existence check, the filter no longer matches
+        // and this update becomes a no-op (MatchedCount == 0).
+        var filter = Builders<Segment>.Filter.And(
+            Builders<Segment>.Filter.Eq(x => x.Id, id),
+            Builders<Segment>.Filter.Lt(x => x.CommittedVersion, version),
+            Builders<Segment>.Filter.Or(
+                Builders<Segment>.Filter.Eq(x => x.Pending, null),
+                Builders<Segment>.Filter.Lt(x => x.Pending!.Version, version)
+            )
+        );
         var update = Builders<Segment>.Update.Set(x => x.Pending, pending);
 
         await Collection.UpdateOneAsync(filter, update);

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingPostgresTests.cs
@@ -211,4 +211,55 @@ public sealed class FeatureFlagCommittedPendingPostgresTests : IAsyncLifetime
         Assert.NotNull(raw.Pending);
         Assert.Equal(3, raw.Pending!.Version);
     }
+
+    [Fact]
+    public async Task SetPending_Stale_Version_Does_Not_Clobber_Newer_Pending()
+    {
+        // #34: stage v3, then a stale v2 stage must NOT overwrite the newer pending.
+        const string key = "b4-setpending-stale";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: true), version: 3);
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: false), version: 2);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
+        Assert.True(raw.Pending.Value.IsEnabled);
+    }
+
+    [Fact]
+    public async Task SetPending_Not_Written_When_Version_Not_Above_Committed()
+    {
+        // #34: committed is already v2; staging v2 (or lower) must write no pending.
+        const string key = "b4-setpending-not-above-committed";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 2;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: true), version: 2);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.Null(raw.Pending);
+    }
+
+    [Fact]
+    public async Task SetPending_Newer_Version_Overwrites_Older_Pending()
+    {
+        // #34: staging v4 over an existing pending v3 must advance the pending to v4.
+        const string key = "b4-setpending-newer";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: false), version: 3);
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: true), version: 4);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(4, raw.Pending!.Version);
+        Assert.True(raw.Pending.Value.IsEnabled);
+    }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingTests.cs
@@ -170,4 +170,59 @@ public sealed class FeatureFlagCommittedPendingTests : IAsyncLifetime
         Assert.NotNull(raw.Pending);
         Assert.Equal(3, raw.Pending!.Version);
     }
+
+    [Fact]
+    public async Task SetPending_Stale_Version_Does_Not_Clobber_Newer_Pending()
+    {
+        // #34: stage v3, then a stale v2 stage must NOT overwrite the newer pending.
+        const string key = "b3-setpending-stale";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        // newer pending (v3) carries IsEnabled = true
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: true), version: 3);
+
+        // stale out-of-order stage (v2) carries IsEnabled = false -> must be a no-op
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: false), version: 2);
+
+        // pending stays v3 with the newer value intact
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
+        Assert.True(raw.Pending.Value.IsEnabled);
+    }
+
+    [Fact]
+    public async Task SetPending_Not_Written_When_Version_Not_Above_Committed()
+    {
+        // #34: committed is already v2; staging v2 (or lower) must write no pending.
+        const string key = "b3-setpending-not-above-committed";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 2;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: true), version: 2);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.Null(raw.Pending);
+    }
+
+    [Fact]
+    public async Task SetPending_Newer_Version_Overwrites_Older_Pending()
+    {
+        // #34: staging v4 over an existing pending v3 must advance the pending to v4.
+        const string key = "b3-setpending-newer";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: false), version: 3);
+        await _sut.SetPendingAsync(_envId, key, CreateFlag(key, isEnabled: true), version: 4);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(4, raw.Pending!.Version);
+        Assert.True(raw.Pending.Value.IsEnabled);
+    }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingPostgresTests.cs
@@ -198,6 +198,54 @@ public sealed class SegmentCommittedPendingPostgresTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SetPending_Stale_Version_Does_Not_Clobber_Newer_Pending()
+    {
+        // #34: stage v3, then a stale v2 stage must NOT overwrite the newer pending.
+        var committed = CreateSegment("s1-setpending-stale", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-stale", "v3"), version: 3);
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-stale", "v2"), version: 2);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
+        Assert.Equal("v3", raw.Pending.Value.Description);
+    }
+
+    [Fact]
+    public async Task SetPending_Not_Written_When_Version_Not_Above_Committed()
+    {
+        // #34: committed is already v2; staging v2 (or lower) must write no pending.
+        var committed = CreateSegment("s1-setpending-not-above-committed", "old");
+        committed.CommittedVersion = 2;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-not-above-committed", "new"), version: 2);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.Null(raw.Pending);
+    }
+
+    [Fact]
+    public async Task SetPending_Newer_Version_Overwrites_Older_Pending()
+    {
+        // #34: staging v4 over an existing pending v3 must advance the pending to v4.
+        var committed = CreateSegment("s1-setpending-newer", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-newer", "v3"), version: 3);
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-newer", "v4"), version: 4);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(4, raw.Pending!.Version);
+        Assert.Equal("v4", raw.Pending.Value.Description);
+    }
+
+    [Fact]
     public async Task GetPending_Returns_Only_Segments_With_Pending()
     {
         var committedOnly = CreateSegment("s1-committed-only", "x");

--- a/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingTests.cs
@@ -161,6 +161,54 @@ public sealed class SegmentCommittedPendingTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SetPending_Stale_Version_Does_Not_Clobber_Newer_Pending()
+    {
+        // #34: stage v3, then a stale v2 stage must NOT overwrite the newer pending.
+        var committed = CreateSegment("s1-setpending-stale", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-stale", "v3"), version: 3);
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-stale", "v2"), version: 2);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(3, raw.Pending!.Version);
+        Assert.Equal("v3", raw.Pending.Value.Description);
+    }
+
+    [Fact]
+    public async Task SetPending_Not_Written_When_Version_Not_Above_Committed()
+    {
+        // #34: committed is already v2; staging v2 (or lower) must write no pending.
+        var committed = CreateSegment("s1-setpending-not-above-committed", "old");
+        committed.CommittedVersion = 2;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-not-above-committed", "new"), version: 2);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.Null(raw.Pending);
+    }
+
+    [Fact]
+    public async Task SetPending_Newer_Version_Overwrites_Older_Pending()
+    {
+        // #34: staging v4 over an existing pending v3 must advance the pending to v4.
+        var committed = CreateSegment("s1-setpending-newer", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-newer", "v3"), version: 3);
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-setpending-newer", "v4"), version: 4);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Equal(4, raw.Pending!.Version);
+        Assert.Equal("v4", raw.Pending.Value.Description);
+    }
+
+    [Fact]
     public async Task GetPending_Returns_Only_Segments_With_Pending()
     {
         var committedOnly = CreateSegment("s1-committed-only", "x");


### PR DESCRIPTION
Closes #34. Without this, an out-of-order/stale stage carrying a version lower than the current pending (but higher than committed) clobbers a newer pending — and the coordinator then commits the stale value.

`SetPendingAsync` (flags + segments, both providers) now writes only when `version > CommittedVersion` AND `version > existing Pending.Version`. Mongo: atomic conditional `UpdateOneAsync` (race-free). EF: load+check+save (residual window documented, like the PromotePending #33 note). Signatures unchanged (no-op on stale).

**Verification (real Mongo + Postgres):** 32 committed/pending tests (flags + segments × Mongo + Postgres), incl. 3 new acceptance cases each (stale v2 doesn't clobber v3; stage==committed writes nothing; v4 overwrites v3); full back-end build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)