### PR TITLE
✨ Segment recovery backfill (#58)

### DIFF
--- a/modules/control-plane/src/Api/Application/ControlPlane/RecoveryWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/RecoveryWorker.cs
@@ -12,11 +12,12 @@ namespace Api.Application.ControlPlane;
 
 /// <summary>
 /// E1 returning-DC recovery (catch-up-before-serve). Under <see cref="ConsistencyMode.GatedCommit"/>
-/// the commit coordinator commits a flag on the LIVE set, so a flag that changed while a DC was
-/// evicted is committed with NO pending — the returned DC's Redis would otherwise stay stale
-/// forever. This worker watches the live set; when a DC newly appears (its lease returns), it
-/// backfills that DC's Redis with the COMMITTED value of every flag (stage the versioned value +
-/// flip the committed pointer + advance the index), so the returned DC catches up.
+/// the commit coordinator commits a flag (and, identically, a segment) on the LIVE set, so a
+/// flag/segment that changed while a DC was evicted is committed with NO pending — the returned DC's
+/// Redis would otherwise stay stale forever. This worker watches the live set; when a DC newly
+/// appears (its lease returns), it backfills that DC's Redis with the COMMITTED value of every flag
+/// AND every segment (stage the versioned value + flip the committed pointer + advance the index),
+/// so the returned DC catches up.
 ///
 /// Model A, locked decisions:
 ///  - A: a separate worker (this one), not folded into the commit coordinator.
@@ -108,8 +109,8 @@ public sealed class RecoveryWorker : BackgroundService
     /// Performs a single recovery tick and returns the number of DCs backfilled. Exposed so it can
     /// be invoked directly (e.g. by integration tests) without waiting on the periodic timer.
     ///
-    /// For each DcId newly present in the live set since the previous tick, every flag's committed
-    /// value is staged and committed into that DC's Redis (targeted, not broadcast).
+    /// For each DcId newly present in the live set since the previous tick, every flag's AND every
+    /// segment's committed value is staged and committed into that DC's Redis (targeted, not broadcast).
     /// </summary>
     public async Task<int> RunOnceAsync(CancellationToken cancellationToken = default)
     {
@@ -117,6 +118,7 @@ public sealed class RecoveryWorker : BackgroundService
         // scope so the singleton BackgroundService does not capture a scoped/disposed instance.
         using var scope = _scopeFactory.CreateScope();
         var featureFlagService = scope.ServiceProvider.GetRequiredService<IFeatureFlagService>();
+        var segmentService = scope.ServiceProvider.GetRequiredService<ISegmentService>();
         var leaseStore = scope.ServiceProvider.GetRequiredService<ILeaseStore>();
 
         // Live DCs = distinct DcIds that currently hold at least one unexpired lease.
@@ -151,6 +153,16 @@ public sealed class RecoveryWorker : BackgroundService
         }
 
         var allCommitted = await featureFlagService.GetAllCommittedAsync();
+        var allCommittedSegments = await segmentService.GetAllCommittedAsync();
+
+        // Resolve each committed segment's target env ids ONCE (not per returned DC): the env ids of a
+        // segment are a function of the segment, independent of which DC is being repaired. Mirrors the
+        // flag loop deriving its own ts but reuses the same envIds across DCs.
+        var segmentEnvIds = new Dictionary<string, ICollection<Guid>>(allCommittedSegments.Count);
+        foreach (var segment in allCommittedSegments)
+        {
+            segmentEnvIds[segment.Id.ToString()] = await segmentService.GetEnvironmentIdsAsync(segment);
+        }
 
         var backfilled = 0;
         foreach (var dcId in returned)
@@ -169,16 +181,31 @@ public sealed class RecoveryWorker : BackgroundService
                 await composite.CommitFlagToDcAsync(dcId, flag.EnvId, flag.Id.ToString(), ts);
             }
 
+            foreach (var segment in allCommittedSegments)
+            {
+                // Same shape as the flag backfill: the committed segment's version token (unix-ms of
+                // UpdatedAt, mirroring SegmentChangeMessageHandler), then stage the versioned value +
+                // flip the committed pointer + per-env index — targeted at ONLY the returned DC.
+                // Idempotent: re-applying an already-present version no-ops.
+                var ts = new DateTimeOffset(segment.UpdatedAt).ToUnixTimeMilliseconds();
+                var envIds = segmentEnvIds[segment.Id.ToString()];
+
+                await composite.StageSegmentToDcAsync(dcId, segment, ts);
+                await composite.CommitSegmentToDcAsync(dcId, envIds, segment.Id.ToString(), ts);
+            }
+
             // D (best-effort client refresh): there is no per-DC client-targeting primitive today, so
             // pushing a full sync to that DC's connected clients is deferred rather than broadcast to
             // ALL DCs (which would defeat the per-DC intent).
             // TODO per-DC client refresh: trigger PushFullSync for dcId's connected clients once a
             // per-DC client-targeting primitive exists.
             _logger.LogInformation(
-                "Recovery: backfilled returning DC {DcId} with {FlagCount} committed flag(s). " +
+                "Recovery: backfilled returning DC {DcId} with {FlagCount} committed flag(s) and " +
+                "{SegmentCount} committed segment(s). " +
                 "TODO per-DC client refresh deferred (no per-DC client targeting yet).",
                 dcId,
-                allCommitted.Count);
+                allCommitted.Count,
+                allCommittedSegments.Count);
 
             backfilled++;
         }

--- a/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
+++ b/modules/control-plane/src/Api/Infrastructure/Caches/CompositeRedisCacheService.cs
@@ -217,6 +217,28 @@ public class CompositeRedisCacheService(
     public Task CommitFlagToDcAsync(string dcId, Guid envId, string flagId, long ts) =>
         TargetedAsync(dcId, s => s.CommitFlagAsync(envId, flagId, ts), nameof(CommitFlagToDcAsync));
 
+    /// <summary>
+    /// Recovery-facing targeted write (#58, segment counterpart of <see cref="StageFlagToDcAsync"/>):
+    /// stages <paramref name="segment"/> at version <paramref name="ts"/> into ONE DC's Redis (the
+    /// <see cref="DcCacheService"/> whose <see cref="DcCacheService.DcId"/> matches
+    /// <paramref name="dcId"/>), unlike the broadcast <see cref="StageSegmentAsync"/>. If no DC
+    /// matches, logs a warning and no-ops. A failing write is swallowed and logged with the same
+    /// resilience as <see cref="BroadcastAsync"/>.
+    /// </summary>
+    public Task StageSegmentToDcAsync(string dcId, Segment segment, long ts) =>
+        TargetedAsync(dcId, s => s.StageSegmentAsync(segment, ts), nameof(StageSegmentToDcAsync));
+
+    /// <summary>
+    /// Recovery-facing targeted write (#58, segment counterpart of <see cref="CommitFlagToDcAsync"/>):
+    /// commits <paramref name="segmentId"/> at version <paramref name="ts"/> into ONE DC's Redis
+    /// (advancing that DC's committed pointer + per-env index), unlike the broadcast
+    /// <see cref="CommitSegmentAsync"/>. If no DC matches <paramref name="dcId"/>, logs a warning and
+    /// no-ops. A failing write is swallowed and logged with the same resilience as
+    /// <see cref="BroadcastAsync"/>.
+    /// </summary>
+    public Task CommitSegmentToDcAsync(string dcId, ICollection<Guid> envIds, string segmentId, long ts) =>
+        TargetedAsync(dcId, s => s.CommitSegmentAsync(envIds, segmentId, ts), nameof(CommitSegmentToDcAsync));
+
     private async Task TargetedAsync(string dcId, Func<ICacheService, Task> action, string operationName)
     {
         var dc = cacheServices.FirstOrDefault(c => c.DcId == dcId);

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/RecoveryWorkerTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/RecoveryWorkerTests.cs
@@ -5,6 +5,7 @@ using Application.ControlPlane;
 using Application.Services;
 using Domain.ControlPlane;
 using Domain.FeatureFlags;
+using Domain.Segments;
 using Infrastructure.Caches.Redis;
 using Infrastructure.Persistence.MongoDb;
 using Infrastructure.Services.MongoDb;
@@ -46,6 +47,7 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
 
     private MongoDbClient _mongoDb = null!;
     private FeatureFlagService _flagService = null!;
+    private SegmentService _segmentService = null!;
     private MongoLeaseStore _leaseStore = null!;
 
     private ConnectionMultiplexer _mux = null!;
@@ -68,6 +70,7 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
         await _mongoDb.Database.RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1));
 
         _flagService = new FeatureFlagService(_mongoDb);
+        _segmentService = new SegmentService(_mongoDb, NullLogger<SegmentService>.Instance);
         _leaseStore = new MongoLeaseStore(_mongoDb);
 
         // ---- Redis (two DB indexes = two DCs) ----
@@ -134,6 +137,24 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
         );
     }
 
+    private Segment CreateSegment(string key, string[] included)
+    {
+        // Environment-specific so GetEnvironmentIdsAsync resolves to [_envId] without any Mongo
+        // env/project/org lookup — the env ids backfilled to the returning DC's index are deterministic.
+        return new Segment(
+            workspaceId: Guid.NewGuid(),
+            envId: _envId,
+            name: key,
+            key: key,
+            type: SegmentType.EnvironmentSpecific,
+            scopes: [],
+            included: included,
+            excluded: [],
+            rules: [],
+            description: string.Empty
+        );
+    }
+
     private async Task UpsertLeaseAsync(string dcId, DateTimeOffset expiresAt)
     {
         await _leaseStore.UpsertLeaseAsync(new DcLease
@@ -151,6 +172,7 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
         // resolves them at runtime via IServiceScopeFactory.
         var services = new ServiceCollection();
         services.AddTransient<IFeatureFlagService>(_ => _flagService);
+        services.AddTransient<ISegmentService>(_ => _segmentService);
         services.AddTransient<ILeaseStore>(_ => _leaseStore);
         var provider = services.BuildServiceProvider();
 
@@ -174,6 +196,10 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
     /// </summary>
     private static long VersionTokenOf(FeatureFlag flag) =>
         new DateTimeOffset(flag.UpdatedAt).ToUnixTimeMilliseconds();
+
+    /// <summary>Segment counterpart of <see cref="VersionTokenOf(FeatureFlag)"/>.</summary>
+    private static long VersionTokenOf(Segment segment) =>
+        new DateTimeOffset(segment.UpdatedAt).ToUnixTimeMilliseconds();
 
     // ----- acceptance -----
 
@@ -251,6 +277,102 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
         // dc-a was untouched by the recovery (it was already live, not returning).
         var dcaPointer = await _mux.GetDatabase(0).StringGetAsync(RedisCaches.FlagCommittedPointer(v2.Id));
         Assert.Equal(v2Ts, (long)dcaPointer);
+    }
+
+    [Fact]
+    public async Task Backfills_ReturningDc_With_LatestCommittedSegmentVersion()
+    {
+        const string flagKey = "returning-dc-flag";
+        const string segmentKey = "returning-dc-segment";
+
+        // ---- a flag at v1 on BOTH DCs so the existing flag backfill path is exercised alongside ----
+        var flag = CreateFlag(flagKey, isEnabled: false);
+        flag.CommittedVersion = 1;
+        await _flagService.AddOneAsync(flag);
+        var flagTs = VersionTokenOf(flag);
+        await _dcaCache.StageFlagAsync(flag, flagTs);
+        await _dcaCache.CommitFlagAsync(_envId, flag.Id.ToString(), flagTs);
+        await _dcbCache.StageFlagAsync(flag, flagTs);
+        await _dcbCache.CommitFlagAsync(_envId, flag.Id.ToString(), flagTs);
+
+        // ---- segment v1 committed on BOTH DCs (both live) ----
+        var s1 = CreateSegment(segmentKey, included: ["alice"]);
+        s1.CommittedVersion = 1;
+        await _segmentService.AddOneAsync(s1);
+        var s1Ts = VersionTokenOf(s1);
+        var envIds = await _segmentService.GetEnvironmentIdsAsync(s1);
+        Assert.Equal(new[] { _envId }, envIds);
+
+        await _dcaCache.StageSegmentAsync(s1, s1Ts);
+        await _dcaCache.CommitSegmentAsync(envIds, s1.Id.ToString(), s1Ts);
+        await _dcbCache.StageSegmentAsync(s1, s1Ts);
+        await _dcbCache.CommitSegmentAsync(envIds, s1.Id.ToString(), s1Ts);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var sut = CreateSut();
+
+        // First tick: both DCs first-seen -> backfilled (harmless), establishes the watermark.
+        await sut.RunOnceAsync();
+
+        // ---- dc-b loses its lease ----
+        await UpsertLeaseAsync(DcB, now.AddMinutes(-5)); // expired
+
+        // ---- segment changes to v2, committed on dc-a ONLY (dc-b absent) ----
+        var s2 = CreateSegment(segmentKey, included: ["alice", "bob"]);
+        s2.Id = s1.Id;
+        s2.CommittedVersion = 2;
+        // ensure a distinct, newer version token than v1
+        s2.UpdatedAt = s1.UpdatedAt.AddSeconds(1);
+        await _segmentService.UpdateAsync(s2);
+        var s2Ts = VersionTokenOf(s2);
+        Assert.NotEqual(s1Ts, s2Ts);
+
+        await _dcaCache.StageSegmentAsync(s2, s2Ts);
+        await _dcaCache.CommitSegmentAsync(envIds, s2.Id.ToString(), s2Ts);
+
+        // dc-b is still at v1 and never got v2.
+        Assert.False(await _dcbCache.HasStagedSegmentAsync(s2.Id, s2Ts));
+        var dcbPointerBefore =
+            await _mux.GetDatabase(1).StringGetAsync(RedisCaches.SegmentCommittedPointer(s2.Id));
+        Assert.Equal(s1Ts, (long)dcbPointerBefore);
+
+        // A recovery tick now sees only dc-a live; nothing returned.
+        var noReturn = await sut.RunOnceAsync();
+        Assert.Equal(0, noReturn);
+
+        // ---- dc-b's lease returns ----
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var backfilled = await sut.RunOnceAsync();
+
+        // exactly one DC (dc-b) backfilled
+        Assert.Equal(1, backfilled);
+
+        // dc-b's Redis now has the segment at v2: versioned value key + committed pointer + index.
+        Assert.True(await _dcbCache.HasStagedSegmentAsync(s2.Id, s2Ts));
+
+        var dcbPointerAfter =
+            await _mux.GetDatabase(1).StringGetAsync(RedisCaches.SegmentCommittedPointer(s2.Id));
+        Assert.Equal(s2Ts, (long)dcbPointerAfter);
+
+        var dcbIndexScore = await _mux.GetDatabase(1)
+            .SortedSetScoreAsync(RedisKeys.SegmentIndex(_envId), s2.Id.ToString());
+        Assert.NotNull(dcbIndexScore);
+        Assert.Equal(s2Ts, (long)dcbIndexScore!.Value);
+
+        // dc-a was untouched by the recovery (it was already live, not returning).
+        var dcaPointer =
+            await _mux.GetDatabase(0).StringGetAsync(RedisCaches.SegmentCommittedPointer(s2.Id));
+        Assert.Equal(s2Ts, (long)dcaPointer);
+
+        // the flag backfill still works (don't regress): dc-b has the flag committed at v1.
+        Assert.True(await _dcbCache.HasStagedFlagAsync(flag.Id, flagTs));
+        var dcbFlagPointer =
+            await _mux.GetDatabase(1).StringGetAsync(RedisCaches.FlagCommittedPointer(flag.Id));
+        Assert.Equal(flagTs, (long)dcbFlagPointer);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #58 (segment analog of E1). `RecoveryWorker` backfilled only flags; segments now have the same gated lifecycle, so a returned DC stayed stale on segments.

Adds per-DC targeted segment writes `StageSegmentToDcAsync`/`CommitSegmentToDcAsync` on the composite (mirror the flag ones via the existing `TargetedAsync` helper), and extends `RecoveryWorker` to backfill each returned DC's committed segments (`GetAllCommittedAsync`, ts = `UpdatedAt` unix-ms, `GetEnvironmentIdsAsync` for envIds) — targeted, no global publish, idempotent.

**Verification (real Mongo + Redis :6391):** 3 recovery tests (new segment backfill to v2 on return + existing flag backfill anti-regression + no-op); full CP integration 23/23; unit 52/52; back-end + CP builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)