### PR TITLE
✨ DcId config-mismatch validation (#48)

### DIFF
--- a/modules/control-plane/src/Api/Application/ControlPlane/DcIdConsistencyChecker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/DcIdConsistencyChecker.cs
@@ -1,0 +1,231 @@
+using System.Diagnostics.Metrics;
+using Api.Infrastructure.Caches;
+using Application.Configuration;
+using Application.ControlPlane;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Application.ControlPlane;
+
+/// <summary>
+/// #48 advisory DcId consistency check. The commit coordinator correlates a configured Redis
+/// instance (<c>Redis:Instances[].DcId</c>) with the live ELS pods reporting leases in that DC
+/// (<see cref="ILeaseStore.GetLiveSetAsync"/> -> <see cref="Domain.ControlPlane.DcLease.DcId"/>,
+/// populated from each ELS pod's <c>ControlPlane:DcId</c>). If those DcId strings disagree, commits
+/// silently stall for the affected DC: the configured DC is never seen "live" so its stage is never
+/// gated on (typo), or an ELS pod reports a DcId the control plane never probes.
+///
+/// This worker periodically WARNS (never fails) when those two DcId sets diverge:
+///  - a configured Redis DcId with NO reporting lease (DC down OR DcId typo), and
+///  - a reporting lease whose DcId matches NO configured Redis instance (an ELS pod in a DC the
+///    control plane does not know about).
+///
+/// It is a no-op unless <see cref="ConsistencyMode.GatedCommit"/> is active (only then do leases /
+/// the gated commit path exist). Empty/ordinal-fallback configured DcIds (see
+/// <see cref="CacheServiceCollectionExtensions"/>) carry no operator-meaningful identity and are
+/// excluded from the comparison.
+///
+/// Advisory only: it changes no commit behavior. It logs and emits an observable gauge on the shared
+/// <see cref="CommitCoordinatorWorker.MeterName"/> meter so operators can alert on a non-zero
+/// unmatched-DC count.
+/// </summary>
+public sealed class DcIdConsistencyChecker : BackgroundService
+{
+    /// <summary>
+    /// Default interval between checks when not overridden via
+    /// <c>ControlPlane:DcIdConsistency:IntervalSeconds</c>.
+    /// </summary>
+    public static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// #48: observable gauge reporting the count of unmatched DCs, tagged <c>direction</c> =
+    /// <c>missing_lease</c> (configured DcId has no reporting lease) | <c>unknown_dc</c> (reporting
+    /// lease's DcId matches no configured Redis instance). Emitted on the shared consistency meter
+    /// (<see cref="CommitCoordinatorWorker.MeterName"/>).
+    /// </summary>
+    public const string UnmatchedDcCountGaugeName = "control_plane.consistency.unmatched_dc_count";
+
+    private static readonly Meter Meter = new(CommitCoordinatorWorker.MeterName);
+
+    // Most recent unmatched counts, refreshed at the end of each tick. Static + volatile so a single
+    // gauge registration on the shared meter survives across worker instances and the gauge callback
+    // may run on a different thread than the tick that updates the fields (matching the coordinator).
+    private static volatile int _missingLeaseCount;
+    private static volatile int _unknownDcCount;
+
+    private static readonly ObservableGauge<long> UnmatchedDcCountGauge = Meter.CreateObservableGauge(
+        UnmatchedDcCountGaugeName,
+        ObserveUnmatchedDcCount,
+        unit: "{dc}",
+        description:
+        "Count of DCs whose configured Redis DcId and reporting ELS lease DcId do not line up, " +
+        "tagged direction = missing_lease | unknown_dc.");
+
+    private static IEnumerable<Measurement<long>> ObserveUnmatchedDcCount()
+    {
+        yield return new Measurement<long>(
+            _missingLeaseCount,
+            new KeyValuePair<string, object?>("direction", "missing_lease"));
+        yield return new Measurement<long>(
+            _unknownDcCount,
+            new KeyValuePair<string, object?>("direction", "unknown_dc"));
+    }
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IConfiguration _configuration;
+    private readonly bool _enabled;
+    private readonly TimeSpan _interval;
+    private readonly ILogger<DcIdConsistencyChecker> _logger;
+
+    public DcIdConsistencyChecker(
+        IServiceScopeFactory scopeFactory,
+        IConfiguration configuration,
+        ILogger<DcIdConsistencyChecker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _configuration = configuration;
+        _logger = logger;
+        _enabled = configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit;
+
+        var seconds = configuration.GetValue<int?>("ControlPlane:DcIdConsistency:IntervalSeconds");
+        _interval = seconds is > 0
+            ? TimeSpan.FromSeconds(seconds.Value)
+            : DefaultInterval;
+    }
+
+    /// <summary>
+    /// Result of comparing the configured Redis DcId set against the reporting lease DcId set.
+    /// </summary>
+    /// <param name="MissingLeases">
+    /// Configured Redis DcIds with NO reporting lease (DC down OR DcId typo), sorted, deduplicated.
+    /// </param>
+    /// <param name="UnknownDcs">
+    /// Reporting lease DcIds matching NO configured Redis instance (an unknown DC), sorted,
+    /// deduplicated.
+    /// </param>
+    public sealed record ComparisonResult(
+        IReadOnlyList<string> MissingLeases,
+        IReadOnlyList<string> UnknownDcs)
+    {
+        public bool HasMismatch => MissingLeases.Count > 0 || UnknownDcs.Count > 0;
+    }
+
+    /// <summary>
+    /// Pure comparison of configured Redis DcIds against reporting lease DcIds. Empty/whitespace
+    /// configured DcIds are excluded (they are ordinal-fallback placeholders with no operator
+    /// identity). Comparison is ordinal (case-sensitive), matching the default <see cref="HashSet{T}"/>
+    /// semantics the lease live-set uses elsewhere, so a case typo surfaces as a genuine mismatch.
+    /// Results are deduplicated and sorted for stable log output. Pure / side-effect-free so it can
+    /// be unit-tested without any infrastructure.
+    /// </summary>
+    public static ComparisonResult Compare(
+        IEnumerable<string?> configuredDcIds,
+        IEnumerable<string?> reportingDcIds)
+    {
+        var configured = configuredDcIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var reporting = reportingDcIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missingLeases = configured
+            .Where(dc => !reporting.Contains(dc))
+            .OrderBy(dc => dc, StringComparer.Ordinal)
+            .ToList();
+
+        var unknownDcs = reporting
+            .Where(dc => !configured.Contains(dc))
+            .OrderBy(dc => dc, StringComparer.Ordinal)
+            .ToList();
+
+        return new ComparisonResult(missingLeases, unknownDcs);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_enabled)
+        {
+            _logger.LogInformation(
+                "DcId consistency checker disabled (consistency mode is not GatedCommit).");
+            return;
+        }
+
+        using var timer = new PeriodicTimer(_interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await RunOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // ignore cancellation from the timer loop itself
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while running the DcId consistency check tick.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs a single check tick: reads the configured Redis DcIds and the reporting lease DcIds,
+    /// compares them, warns on each mismatch, and refreshes the unmatched-DC gauge. Returns the
+    /// comparison result. Exposed so it can be invoked directly (e.g. by integration tests) without
+    /// waiting on the periodic timer.
+    /// </summary>
+    public async Task<ComparisonResult> RunOnceAsync(CancellationToken cancellationToken = default)
+    {
+        // The configured DcIds are read from the SAME Redis:Instances section the cache extension
+        // binds (see CacheServiceCollectionExtensions.AddRedis). Empty DcIds are ordinal-fallback
+        // placeholders and are excluded by Compare.
+        var configuredDcIds = _configuration
+            .GetSection("Redis:Instances")
+            .Get<RedisInstanceConfig[]>()?
+            .Select(instance => instance.DcId)
+            ?? [];
+
+        // ILeaseStore is scoped (per-request) in DI; resolve it inside a scope so the singleton
+        // BackgroundService does not capture a scoped/disposed instance (mirrors the coordinator).
+        using var scope = _scopeFactory.CreateScope();
+        var leaseStore = scope.ServiceProvider.GetRequiredService<ILeaseStore>();
+
+        var liveSet = await leaseStore.GetLiveSetAsync(DateTimeOffset.UtcNow);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var reportingDcIds = liveSet.Select(lease => lease.DcId);
+
+        var result = Compare(configuredDcIds, reportingDcIds);
+
+        // Refresh the observable gauge from this tick regardless of mismatch, so a return to a
+        // matched state resets the reported count back to zero.
+        _missingLeaseCount = result.MissingLeases.Count;
+        _unknownDcCount = result.UnknownDcs.Count;
+
+        if (result.MissingLeases.Count > 0)
+        {
+            _logger.LogWarning(
+                "DcId consistency: configured Redis DC(s) {MissingDcs} have no reporting ELS lease " +
+                "(the DC is down OR its configured DcId does not match the ELS ControlPlane:DcId). " +
+                "Commits will stall for these DC(s) until a matching lease is reported.",
+                string.Join(", ", result.MissingLeases));
+        }
+
+        if (result.UnknownDcs.Count > 0)
+        {
+            _logger.LogWarning(
+                "DcId consistency: ELS pod(s) report lease DC(s) {UnknownDcs} that match no " +
+                "configured Redis instance (an unknown DC the control plane cannot stage to). " +
+                "Add a Redis:Instances entry with a matching DcId, or fix the ELS ControlPlane:DcId.",
+                string.Join(", ", result.UnknownDcs));
+        }
+
+        return result;
+    }
+}

--- a/modules/control-plane/src/Api/Setup/ServicesRegister.cs
+++ b/modules/control-plane/src/Api/Setup/ServicesRegister.cs
@@ -62,6 +62,10 @@ public static class ServicesRegister
         // lease returns to the live set. No-ops unless ControlPlane:ConsistencyMode == GatedCommit.
         builder.Services.AddHostedService<RecoveryWorker>();
 
+        // #48 advisory DcId consistency check: warns (never fails) when the configured Redis DcId set
+        // and the reporting ELS lease DcId set diverge. No-ops unless ConsistencyMode == GatedCommit.
+        builder.Services.AddHostedService<DcIdConsistencyChecker>();
+
         return builder;
     }
     

--- a/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/DcIdConsistencyCheckerTests.cs
+++ b/modules/control-plane/tests/Api.UnitTests/Application/ControlPlane/DcIdConsistencyCheckerTests.cs
@@ -1,0 +1,89 @@
+using Api.Application.ControlPlane;
+
+namespace Api.UnitTests.Application.ControlPlane;
+
+public class DcIdConsistencyCheckerTests
+{
+    [Fact]
+    public void Compare_WhenConfiguredDcHasNoReportingLease_ReportsMissingLease()
+    {
+        // Acceptance: configured {west, east}, leases report {west} -> "east has no reporting lease".
+        var configured = new[] { "west", "east" };
+        var reporting = new[] { "west" };
+
+        var result = DcIdConsistencyChecker.Compare(configured, reporting);
+
+        Assert.Equal(new[] { "east" }, result.MissingLeases);
+        Assert.Empty(result.UnknownDcs);
+    }
+
+    [Fact]
+    public void Compare_WhenReportingDcIsNotConfigured_ReportsUnknownDc()
+    {
+        // Acceptance: leases report {west, south}, configured {west} -> "south is an unknown DC".
+        var configured = new[] { "west" };
+        var reporting = new[] { "west", "south" };
+
+        var result = DcIdConsistencyChecker.Compare(configured, reporting);
+
+        Assert.Empty(result.MissingLeases);
+        Assert.Equal(new[] { "south" }, result.UnknownDcs);
+    }
+
+    [Fact]
+    public void Compare_WhenAllMatch_ReportsNoMismatch()
+    {
+        // Acceptance: all-match -> no warning.
+        var configured = new[] { "west", "east" };
+        var reporting = new[] { "east", "west" };
+
+        var result = DcIdConsistencyChecker.Compare(configured, reporting);
+
+        Assert.Empty(result.MissingLeases);
+        Assert.Empty(result.UnknownDcs);
+        Assert.False(result.HasMismatch);
+    }
+
+    [Fact]
+    public void Compare_IsCaseSensitiveAndOrdinal_MatchingLeaseStoreDcIdSemantics()
+    {
+        // Lease DcIds are compared ordinally elsewhere (HashSet<string> default), so a case
+        // difference is a genuine mismatch (a likely typo), surfaced on both sides.
+        var configured = new[] { "West" };
+        var reporting = new[] { "west" };
+
+        var result = DcIdConsistencyChecker.Compare(configured, reporting);
+
+        Assert.Equal(new[] { "West" }, result.MissingLeases);
+        Assert.Equal(new[] { "west" }, result.UnknownDcs);
+        Assert.True(result.HasMismatch);
+    }
+
+    [Fact]
+    public void Compare_IgnoresEmptyOrWhitespaceConfiguredDcIds()
+    {
+        // Empty/ordinal-fallback configured DcIds carry no operator-meaningful identity, so they
+        // are excluded from the comparison rather than reported as missing leases.
+        var configured = new[] { "west", "", "  " };
+        var reporting = new[] { "west" };
+
+        var result = DcIdConsistencyChecker.Compare(configured, reporting);
+
+        Assert.Empty(result.MissingLeases);
+        Assert.Empty(result.UnknownDcs);
+    }
+
+    [Fact]
+    public void Compare_DeduplicatesAndSortsForStableMessages()
+    {
+        var configured = new[] { "east", "west", "east" };
+        var reporting = new[] { "north", "south", "north" };
+
+        var result = DcIdConsistencyChecker.Compare(configured, reporting);
+
+        // both configured DcIds lack a reporting lease, sorted for stable log output
+        Assert.Equal(new[] { "east", "west" }, result.MissingLeases);
+        // both reporting DcIds are unknown, sorted
+        Assert.Equal(new[] { "north", "south" }, result.UnknownDcs);
+    }
+}


### PR DESCRIPTION
Closes #48. The coordinator's join key is `DcId`, set in two services' configs (control-plane `Redis:Instances[].DcId` ↔ ELS `ControlPlane:DcId` via leases). A mismatch silently stalls commits for that DC.

`DcIdConsistencyChecker` (BackgroundService, GatedCommit only, `ControlPlane:DcIdConsistency:IntervalSeconds` default 60): compares configured Redis DcIds vs reporting lease DcIds and **warns** (never fails) on each side — configured-but-no-lease ("commits will stall") and lease-but-unknown-DC — naming the offenders. Plus observable gauge `control_plane.consistency.unmatched_dc_count` (tagged `direction`) on the shared meter. Pure `Compare()` is unit-tested.

**Verification (unit, no infra):** 6 tests (east-missing-lease warns; unknown south warns; all-match clean; case-sensitivity; empty-DcId exclusion; dedup/sort); full unit suite 58/58; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)