### PR TITLE
✨ Per-DC client refresh after recovery (#54)

### DIFF
--- a/modules/back-end/src/Domain/Messages/ControlPlaneCommand.cs
+++ b/modules/back-end/src/Domain/Messages/ControlPlaneCommand.cs
@@ -7,6 +7,13 @@ public class ControlPlaneCommand
     public Action Action { get; set; }
 
     public string ConnectionId { get; set; } = "*";
+
+    /// <summary>
+    /// Optional data center filter. When non-null, only eval servers whose own DcId
+    /// (config "ControlPlane:DcId") equals this value act on the command; all others ignore it.
+    /// When null (the default) every DC acts on it — the original broadcast behavior.
+    /// </summary>
+    public string? TargetDcId { get; set; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/modules/control-plane/src/Api/Application/ControlPlane/RecoveryWorker.cs
+++ b/modules/control-plane/src/Api/Application/ControlPlane/RecoveryWorker.cs
@@ -3,10 +3,12 @@ using Application.Configuration;
 using Application.ControlPlane;
 using Application.Services;
 using Api.Infrastructure.Caches;
+using Domain.Messages;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Action = Domain.Messages.Action;
 
 namespace Api.Application.ControlPlane;
 
@@ -25,8 +27,10 @@ namespace Api.Application.ControlPlane;
 ///       <see cref="CompositeRedisCacheService.CommitFlagToDcAsync"/>) — only the returned DC is
 ///       written, never a broadcast.
 ///  - C: no readiness gate — backfill runs as soon as the DC is seen live.
-///  - D: best-effort client refresh — no per-DC client-targeting primitive exists today, so this is
-///       logged as a TODO rather than pushed to ALL DCs (which would defeat the per-DC intent).
+///  - D: per-DC client refresh — after a returned DC's backfill, a <c>PushFullSync</c> command is
+///       published with <see cref="ControlPlaneCommand.TargetDcId"/> set to that DcId, so only that
+///       DC's eval servers refresh their connected SDK clients (others ignore the targeted command).
+///       Best-effort: a publish failure is logged but does NOT fail the backfill.
 ///
 /// Idempotent: re-staging/re-committing an already-present version is a no-op (the staged value key
 /// and committed pointer are version-keyed). It does NOT publish <c>Topics.FeatureFlagChange</c> —
@@ -35,6 +39,12 @@ namespace Api.Application.ControlPlane;
 /// TODO: leader election if control plane runs multiple replicas. Today multiple replicas would each
 /// run this loop; the staged-write + commit-pointer flip are idempotent so it is safe (at worst
 /// redundant writes), but a leader election would avoid the duplicate work. Out of scope here.
+///
+/// ASSUMPTION (per-DC client refresh): the targeted <c>PushFullSync</c> command relies on the
+/// <see cref="ControlPlaneTopics.ControlPlaneCommand"/> topic reaching EVERY DC's eval servers (the
+/// existing admin "push full sync to ALL active clients" implies it does). The TargetDcId filter then
+/// scopes who acts. If, in some MQ topologies, control-plane commands are delivered only locally,
+/// remote-DC targeting would additionally need a per-DC command publish — a follow-up, NOT built here.
 /// </summary>
 public sealed class RecoveryWorker : BackgroundService
 {
@@ -46,6 +56,7 @@ public sealed class RecoveryWorker : BackgroundService
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICacheService _compositeCache;
+    private readonly IMessageProducer _messageProducer;
     private readonly bool _enabled;
     private readonly TimeSpan _interval;
     private readonly ILogger<RecoveryWorker> _logger;
@@ -58,11 +69,13 @@ public sealed class RecoveryWorker : BackgroundService
     public RecoveryWorker(
         IServiceScopeFactory scopeFactory,
         [FromKeyedServices("compositeCache")] ICacheService compositeCache,
+        IMessageProducer messageProducer,
         IConfiguration configuration,
         ILogger<RecoveryWorker> logger)
     {
         _scopeFactory = scopeFactory;
         _compositeCache = compositeCache;
+        _messageProducer = messageProducer;
         _logger = logger;
         _enabled = configuration.GetConsistencyMode() == ConsistencyMode.GatedCommit;
 
@@ -194,22 +207,47 @@ public sealed class RecoveryWorker : BackgroundService
                 await composite.CommitSegmentToDcAsync(dcId, envIds, segment.Id.ToString(), ts);
             }
 
-            // D (best-effort client refresh): there is no per-DC client-targeting primitive today, so
-            // pushing a full sync to that DC's connected clients is deferred rather than broadcast to
-            // ALL DCs (which would defeat the per-DC intent).
-            // TODO per-DC client refresh: trigger PushFullSync for dcId's connected clients once a
-            // per-DC client-targeting primitive exists.
             _logger.LogInformation(
                 "Recovery: backfilled returning DC {DcId} with {FlagCount} committed flag(s) and " +
-                "{SegmentCount} committed segment(s). " +
-                "TODO per-DC client refresh deferred (no per-DC client targeting yet).",
+                "{SegmentCount} committed segment(s).",
                 dcId,
                 allCommitted.Count,
                 allCommittedSegments.Count);
+
+            // D (per-DC client refresh): the returned DC's Redis is now current, but SDK clients still
+            // connected to that DC's eval servers hold stale values until they reconnect. Publish a
+            // PushFullSync command TARGETED at this DcId so only that DC's eval servers refresh their
+            // clients (others ignore the TargetDcId-scoped command). Best-effort: a publish failure is
+            // logged but does NOT fail the backfill — the Redis repair already succeeded.
+            await PublishClientRefreshAsync(dcId);
 
             backfilled++;
         }
 
         return backfilled;
+    }
+
+    /// <summary>
+    /// Best-effort: publish a <see cref="Action.PushFullSync"/> command scoped to <paramref name="dcId"/>
+    /// (<see cref="ControlPlaneCommand.TargetDcId"/>) so only that DC's eval servers refresh their
+    /// connected SDK clients after the backfill. A publish failure is logged and swallowed — it must
+    /// not fail the backfill that already repaired the DC's Redis.
+    /// </summary>
+    private async Task PublishClientRefreshAsync(string dcId)
+    {
+        try
+        {
+            await _messageProducer.PublishAsync(
+                ControlPlaneTopics.ControlPlaneCommand,
+                new ControlPlaneCommand { Action = Action.PushFullSync, TargetDcId = dcId });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Recovery: failed to publish per-DC client refresh (PushFullSync) for returning DC {DcId}. " +
+                "Backfill succeeded; clients on that DC will refresh on their next reconnect.",
+                dcId);
+        }
     }
 }

--- a/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/RecoveryWorkerTests.cs
+++ b/modules/control-plane/tests/Api.IntegrationTests/ControlPlane/RecoveryWorkerTests.cs
@@ -5,6 +5,7 @@ using Application.ControlPlane;
 using Application.Services;
 using Domain.ControlPlane;
 using Domain.FeatureFlags;
+using Domain.Messages;
 using Domain.Segments;
 using Infrastructure.Caches.Redis;
 using Infrastructure.Persistence.MongoDb;
@@ -16,6 +17,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using StackExchange.Redis;
+using Action = Domain.Messages.Action;
 
 namespace Api.IntegrationTests.ControlPlane;
 
@@ -54,6 +56,9 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
     private RedisCacheService _dcaCache = null!; // db 0
     private RedisCacheService _dcbCache = null!; // db 1
     private CompositeRedisCacheService _composite = null!;
+
+    // Spy producer the SUT publishes the per-DC client-refresh command to. Set by CreateSut.
+    private RecordingMessageProducer _producer = null!;
 
     private static string RedisConnectionString =>
         Environment.GetEnvironmentVariable("E1_REDIS") ?? DefaultRedis;
@@ -183,9 +188,12 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
             })
             .Build();
 
+        _producer = new RecordingMessageProducer();
+
         return new RecoveryWorker(
             provider.GetRequiredService<IServiceScopeFactory>(),
             _composite,
+            _producer,
             configuration,
             logger ?? NullLogger<RecoveryWorker>.Instance);
     }
@@ -405,7 +413,81 @@ public sealed class RecoveryWorkerTests : IAsyncLifetime
         Assert.Equal(0, second);
     }
 
+    [Fact]
+    public async Task Publishes_Targeted_ClientRefresh_For_ReturningDc()
+    {
+        const string key = "returning-dc-refresh";
+
+        // ---- v1 committed on BOTH DCs (both live) ----
+        var v1 = CreateFlag(key, isEnabled: false);
+        v1.CommittedVersion = 1;
+        await _flagService.AddOneAsync(v1);
+        var v1Ts = VersionTokenOf(v1);
+
+        await _dcaCache.StageFlagAsync(v1, v1Ts);
+        await _dcaCache.CommitFlagAsync(_envId, v1.Id.ToString(), v1Ts);
+        await _dcbCache.StageFlagAsync(v1, v1Ts);
+        await _dcbCache.CommitFlagAsync(_envId, v1.Id.ToString(), v1Ts);
+
+        var now = DateTimeOffset.UtcNow;
+        await UpsertLeaseAsync(DcA, now.AddMinutes(5));
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));
+
+        var sut = CreateSut();
+
+        // First tick: both DCs first-seen -> both backfilled -> a targeted command per DC.
+        await sut.RunOnceAsync();
+
+        var firstTickCommands = _producer.Published
+            .Where(p => p.Topic == ControlPlaneTopics.ControlPlaneCommand)
+            .Select(p => (ControlPlaneCommand)p.Message)
+            .ToList();
+        Assert.Equal(2, firstTickCommands.Count);
+        Assert.All(firstTickCommands, c => Assert.Equal(Action.PushFullSync, c.Action));
+        Assert.Contains(firstTickCommands, c => c.TargetDcId == DcA);
+        Assert.Contains(firstTickCommands, c => c.TargetDcId == DcB);
+
+        // ---- steady state: same live set -> nothing returned -> NO new commands published ----
+        var publishedBefore = _producer.Published.Count;
+        var noReturn = await sut.RunOnceAsync();
+        Assert.Equal(0, noReturn);
+        Assert.Equal(publishedBefore, _producer.Published.Count);
+
+        // ---- dc-b leaves then returns -> exactly one targeted command, for dc-b only ----
+        await UpsertLeaseAsync(DcB, now.AddMinutes(-5)); // expired
+        await sut.RunOnceAsync();                        // dc-b drops out of the live set (no return)
+        var beforeReturn = _producer.Published.Count;
+
+        await UpsertLeaseAsync(DcB, now.AddMinutes(5));  // dc-b returns
+        var backfilled = await sut.RunOnceAsync();
+        Assert.Equal(1, backfilled);
+
+        var returnCommands = _producer.Published
+            .Skip(beforeReturn)
+            .Where(p => p.Topic == ControlPlaneTopics.ControlPlaneCommand)
+            .Select(p => (ControlPlaneCommand)p.Message)
+            .ToList();
+        var refresh = Assert.Single(returnCommands);
+        Assert.Equal(Action.PushFullSync, refresh.Action);
+        Assert.Equal(DcB, refresh.TargetDcId);
+    }
+
     // ----- test doubles -----
+
+    /// <summary>
+    /// Spy <see cref="IMessageProducer"/> that records every (topic, message) published, so a test can
+    /// assert the per-DC client-refresh <see cref="ControlPlaneCommand"/> was published after backfill.
+    /// </summary>
+    private sealed class RecordingMessageProducer : IMessageProducer
+    {
+        public List<(string Topic, object Message)> Published { get; } = new();
+
+        public Task PublishAsync<TMessage>(string topic, TMessage message) where TMessage : class
+        {
+            Published.Add((topic, message));
+            return Task.CompletedTask;
+        }
+    }
 
     private sealed class TestRedisClient(IConnectionMultiplexer connection, int db) : IRedisClient
     {

--- a/modules/evaluation-server/src/Domain/Messages/ControlPlaneCommand.cs
+++ b/modules/evaluation-server/src/Domain/Messages/ControlPlaneCommand.cs
@@ -7,6 +7,13 @@ public class ControlPlaneCommand
     public Action Action { get; set; }
 
     public string ConnectionId { get; set; } = "*";
+
+    /// <summary>
+    /// Optional data center filter. When non-null, only eval servers whose own DcId
+    /// (config "ControlPlane:DcId") equals this value act on the command; all others ignore it.
+    /// When null (the default) every DC acts on it — the original broadcast behavior.
+    /// </summary>
+    public string? TargetDcId { get; set; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/modules/evaluation-server/src/Streaming/Consumers/ControlPlaneCommandMessageConsumer.cs
+++ b/modules/evaluation-server/src/Streaming/Consumers/ControlPlaneCommandMessageConsumer.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Domain.Messages;
 using Domain.Shared;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Streaming.Services;
 using Action = Domain.Messages.Action;
@@ -9,6 +10,7 @@ namespace Streaming.Consumers;
 
 public class ControlPlaneCommandMessageConsumer(
     IAdminService adminService,
+    IConfiguration configuration,
     ILogger<ControlPlaneCommandMessageConsumer> logger) : IMessageConsumer
 {
     public string Topic => Topics.ControlPlaneCommand;
@@ -22,6 +24,24 @@ public class ControlPlaneCommandMessageConsumer(
             {
                 logger.LogWarning("Invalid control plane command message format: {Message}", message);
                 return;
+            }
+
+            // Per-DC targeting: when the command names a TargetDcId, only the matching DC's eval
+            // servers act on it; everyone else ignores it. A null TargetDcId keeps the original
+            // broadcast behavior (every DC acts). Read the local DcId the same way GetDcId() does
+            // (config key "ControlPlane:DcId"); Streaming does not reference the Api project where
+            // that extension lives, so the key is read directly here.
+            if (!string.IsNullOrEmpty(command.TargetDcId))
+            {
+                var localDcId = configuration.GetValue<string>("ControlPlane:DcId");
+                if (!string.Equals(command.TargetDcId, localDcId, StringComparison.Ordinal))
+                {
+                    logger.LogDebug(
+                        "Ignoring control plane command targeted at DC '{TargetDcId}' (local DC is '{LocalDcId}').",
+                        command.TargetDcId,
+                        localDcId);
+                    return;
+                }
             }
 
             switch (command.Action)

--- a/modules/evaluation-server/tests/Streaming.UnitTests/Consumers/ControlPlaneCommandMessageConsumerTests.cs
+++ b/modules/evaluation-server/tests/Streaming.UnitTests/Consumers/ControlPlaneCommandMessageConsumerTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Domain.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Streaming.Consumers;
+using Streaming.Services;
+using Action = Domain.Messages.Action;
+
+namespace Streaming.UnitTests.Consumers;
+
+/// <summary>
+/// Verifies the per-DC <see cref="ControlPlaneCommand.TargetDcId"/> filter on the eval-server
+/// consumer: a command targeted at THIS pod's DC (config "ControlPlane:DcId") is acted on, a command
+/// targeted at a DIFFERENT DC is ignored, and a null TargetDcId is acted on by everyone (the original
+/// broadcast behavior). Pure unit test — a mock <see cref="IAdminService"/> asserts whether the
+/// full-sync was invoked.
+/// </summary>
+public class ControlPlaneCommandMessageConsumerTests
+{
+    private readonly Mock<IAdminService> _adminService = new();
+
+    private ControlPlaneCommandMessageConsumer CreateSut(string? localDcId)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ControlPlane:DcId"] = localDcId
+            })
+            .Build();
+
+        return new ControlPlaneCommandMessageConsumer(
+            _adminService.Object,
+            configuration,
+            NullLogger<ControlPlaneCommandMessageConsumer>.Instance);
+    }
+
+    private static string Serialize(ControlPlaneCommand command) =>
+        JsonSerializer.Serialize(command);
+
+    [Fact]
+    public async Task TargetDcId_Matches_LocalDc_Acts()
+    {
+        var sut = CreateSut(localDcId: "west");
+        var message = Serialize(new ControlPlaneCommand { Action = Action.PushFullSync, TargetDcId = "west" });
+
+        await sut.HandleAsync(message, CancellationToken.None);
+
+        _adminService.Verify(x => x.PushFullSyncToAllActiveClients(), Times.Once);
+    }
+
+    [Fact]
+    public async Task TargetDcId_DoesNotMatch_LocalDc_Ignored()
+    {
+        var sut = CreateSut(localDcId: "east");
+        var message = Serialize(new ControlPlaneCommand { Action = Action.PushFullSync, TargetDcId = "west" });
+
+        await sut.HandleAsync(message, CancellationToken.None);
+
+        _adminService.Verify(x => x.PushFullSyncToAllActiveClients(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TargetDcId_Null_Acts_OnEveryDc()
+    {
+        // No TargetDcId -> broadcast. The local DcId is irrelevant.
+        var sut = CreateSut(localDcId: "east");
+        var message = Serialize(new ControlPlaneCommand { Action = Action.PushFullSync, TargetDcId = null });
+
+        await sut.HandleAsync(message, CancellationToken.None);
+
+        _adminService.Verify(x => x.PushFullSyncToAllActiveClients(), Times.Once);
+    }
+
+    [Fact]
+    public async Task TargetDcId_Set_But_LocalDcUnset_Ignored()
+    {
+        // A pod with no configured DcId cannot match a targeted command -> it must ignore it.
+        var sut = CreateSut(localDcId: null);
+        var message = Serialize(new ControlPlaneCommand { Action = Action.PushFullSync, TargetDcId = "west" });
+
+        await sut.HandleAsync(message, CancellationToken.None);
+
+        _adminService.Verify(x => x.PushFullSyncToAllActiveClients(), Times.Never);
+    }
+}


### PR DESCRIPTION
Closes #54. After `RecoveryWorker` backfills a returned DC's Redis, SDK clients still connected to that DC held stale values until reconnect. Now they're refreshed.

- `ControlPlaneCommand` gains optional `TargetDcId` (both copies: back-end + eval-server `Domain.Messages`; null = all = current behavior).
- `ControlPlaneCommandMessageConsumer` ignores a command whose `TargetDcId` ≠ this pod's `ControlPlane:DcId`.
- `RecoveryWorker` publishes `PushFullSync { TargetDcId = dcId }` after each returned DC's backfill (best-effort; never fails the backfill).

**Assumption (documented in-code):** the `ControlPlaneCommand` topic reaches all DCs' eval servers (the existing global admin push implies it does). If some MQ topology delivers commands only locally, remote targeting would need a per-DC command publish — noted as a follow-up, not built here.

**Verification:** consumer filter unit 4/4 (match acts, mismatch ignored, null acts, local-unset ignored); Streaming.UnitTests 72/72; CP unit 58/58; RecoveryWorker integration 4/4 (spy producer asserts targeted publish per returned DC, real Mongo + Redis :6392); all three builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)