### PR TITLE
✨ Version-gated eval-server segment reads (#21)

### DIFF
--- a/modules/evaluation-server/src/Infrastructure/Caches/Redis/RedisKeys.cs
+++ b/modules/evaluation-server/src/Infrastructure/Caches/Redis/RedisKeys.cs
@@ -8,6 +8,7 @@ public static class RedisKeys
     private const string FlagCommittedPrefix = "featbit:flag-committed:";
     private const string FlagIndexPrefix = "featbit:flag-index:";
     private const string SegmentPrefix = "featbit:segment:";
+    private const string SegmentCommittedPrefix = "featbit:segment-committed:";
     private const string SegmentIndexPrefix = "featbit:segment-index:";
     private const string SecretPrefix = "featbit:secret:";
     private const string RateLimitPrefix = "featbit:rl:";
@@ -38,6 +39,27 @@ public static class RedisKeys
     public static RedisKey SegmentIndex(Guid envId) => new($"{SegmentIndexPrefix}{envId}");
 
     public static RedisKey Segment(string id) => new($"{SegmentPrefix}{id}");
+
+    // --- Stage/commit read keys (mirror back-end RedisCaches B2 conventions) ---------------------
+    // The back-end gated segment commit path writes a per-version snapshot under a versioned key
+    // derived from the segment value key, plus a committed-pointer key recording the authoritative
+    // version:
+    //   featbit:segment:{id}:v{ts}        -- immutable per-version snapshot ("staged" value)
+    //   featbit:segment-committed:{id}    -- value is the committed timestamp ({ts}) as a string
+    // RedisStore reads the pointer to resolve which versioned value is authoritative; when the
+    // pointer is absent it falls back to the legacy single-value Segment key (BestEffort path).
+
+    /// <summary>
+    /// The versioned, immutable value key for a single staged segment version:
+    /// <c>featbit:segment:{id}:v{ts}</c>.
+    /// </summary>
+    public static RedisKey SegmentVersion(string id, long ts) => new($"{SegmentPrefix}{id}:v{ts}");
+
+    /// <summary>
+    /// The committed-pointer key holding the timestamp of the currently committed segment version:
+    /// <c>featbit:segment-committed:{id}</c>.
+    /// </summary>
+    public static RedisKey SegmentCommittedPointer(string id) => new($"{SegmentCommittedPrefix}{id}");
 
     public static RedisKey Secret(string secretString) => new($"{SecretPrefix}{secretString}");
 

--- a/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
+++ b/modules/evaluation-server/src/Infrastructure/Store/RedisStore.cs
@@ -35,7 +35,7 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
     /// which writes the main key + index and never writes pointers). This auto-adapts to either
     /// mode without a mode flag. Pointer GETs and value GETs are each batched via
     /// <see cref="Task.WhenAll(System.Threading.Tasks.Task[])"/> to avoid serial round-trips.
-    /// NOTE: segments are intentionally left unchanged here; that is tracked separately as D4.
+    /// The analogous segment read path lives in <see cref="GetSegmentsByIdsAsync"/>.
     /// </summary>
     private async Task<IEnumerable<byte[]>> GetFlagsByIdsAsync(IEnumerable<string> ids)
     {
@@ -64,22 +64,17 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
 
     public async Task<byte[]> GetSegmentAsync(string id)
     {
-        var key = RedisKeys.Segment(id);
-        var segment = await Redis.StringGetAsync(key);
-
-        return (byte[])segment!;
+        var values = await GetSegmentsByIdsAsync(new[] { id });
+        return values[0];
     }
 
     public async Task<IEnumerable<byte[]>> GetSegmentsAsync(Guid envId, long timestamp)
     {
-        // get segment keys
+        // get segment ids from the index sorted set
         var index = RedisKeys.SegmentIndex(envId);
         var ids = await Redis.SortedSetRangeByScoreAsync(index, timestamp, exclude: Exclude.Start);
-        var keys = ids.Select(id => RedisKeys.Segment(id!));
 
-        // get segments
-        var tasks = keys.Select(key => Redis.StringGetAsync(key));
-        var values = await Task.WhenAll(tasks);
+        var values = await GetSegmentsByIdsAsync(ids.Select(id => id.ToString()));
 
         // for shared segments, replace empty envId with actual envId
         const string emptyEnvId = "\"envId\":\"\",";
@@ -87,7 +82,7 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
         List<byte[]> jsonBytes = [];
         foreach (var value in values)
         {
-            var strValue = (string)value!;
+            var strValue = Encoding.UTF8.GetString(value);
             if (strValue.Contains(emptyEnvId))
             {
                 var newStrValue = strValue.Replace(emptyEnvId, $"\"envId\":\"{envId}\",");
@@ -95,11 +90,47 @@ public class RedisStore(IRedisClient redisClient) : IDbStore
             }
             else
             {
-                jsonBytes.Add((byte[])value!);
+                jsonBytes.Add(value);
             }
         }
 
         return jsonBytes;
+    }
+
+    /// <summary>
+    /// Reads segment values honoring the committed pointer written by the back-end gated commit
+    /// path. For each id: if the committed-pointer key <c>featbit:segment-committed:{id}</c> exists,
+    /// the authoritative value is the versioned snapshot <c>featbit:segment:{id}:v{pointer}</c>;
+    /// otherwise it falls back to the legacy single-value key <c>featbit:segment:{id}</c> (the
+    /// BestEffort path, which writes the main key + index and never writes pointers). This mirrors
+    /// the flag read path in <see cref="GetFlagsByIdsAsync"/>; pointer GETs and value GETs are each
+    /// batched via <see cref="Task.WhenAll(System.Threading.Tasks.Task[])"/> to avoid serial
+    /// round-trips. The shared-segment empty-envId replacement is applied by the caller to whichever
+    /// value is read.
+    /// </summary>
+    private async Task<byte[][]> GetSegmentsByIdsAsync(IEnumerable<string> ids)
+    {
+        var idList = ids.ToList();
+
+        // batch the committed-pointer GETs
+        var pointerTasks = idList.Select(id => Redis.StringGetAsync(RedisKeys.SegmentCommittedPointer(id)));
+        var pointers = await Task.WhenAll(pointerTasks);
+
+        // resolve each id to its authoritative value key: versioned snapshot if a pointer exists,
+        // otherwise the legacy main key (BestEffort fallback)
+        var valueKeys = idList.Select((id, i) =>
+        {
+            var pointer = pointers[i];
+            return pointer.HasValue
+                ? RedisKeys.SegmentVersion(id, (long)pointer)
+                : RedisKeys.Segment(id);
+        });
+
+        // batch the value GETs
+        var valueTasks = valueKeys.Select(key => Redis.StringGetAsync(key));
+        var values = await Task.WhenAll(valueTasks);
+
+        return values.Select(x => (byte[])x!).ToArray();
     }
 
     public async Task<Secret?> GetSecretAsync(string secretString)

--- a/modules/evaluation-server/tests/Application.IntegrationTests/Store/RedisStoreSegmentCommittedPointerTests.cs
+++ b/modules/evaluation-server/tests/Application.IntegrationTests/Store/RedisStoreSegmentCommittedPointerTests.cs
@@ -1,0 +1,178 @@
+using System.Text;
+using Infrastructure.Caches.Redis;
+using Infrastructure.Store;
+using Microsoft.Extensions.Configuration;
+using StackExchange.Redis;
+
+namespace Application.IntegrationTests.Store;
+
+/// <summary>
+/// D4 integration tests: <see cref="RedisStore"/> segment reads must honor the committed pointer
+/// written by the back-end gated commit path (<c>featbit:segment-committed:{id}</c>), and fall back
+/// to the legacy main key (<c>featbit:segment:{id}</c>) otherwise. Mirrors the D2 flag tests in
+/// <see cref="RedisStoreCommittedPointerTests"/>.
+///
+/// Requires a throwaway Redis on port 6393:
+///   docker run -d --rm -p 6393:6379 --name d4seg-redis redis:7-alpine
+/// </summary>
+public class RedisStoreSegmentCommittedPointerTests : IDisposable
+{
+    private const string ConnectionString = "localhost:6393,abortConnect=false,connectTimeout=2000";
+
+    private readonly RedisClient _redisClient;
+    private readonly IDatabase _db;
+    private readonly RedisStore _sut;
+
+    public RedisStoreSegmentCommittedPointerTests()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Redis:ConnectionString"] = ConnectionString
+            })
+            .Build();
+
+        _redisClient = new RedisClient(configuration);
+        _db = _redisClient.GetDatabase();
+        _sut = new RedisStore(_redisClient);
+    }
+
+    private static byte[] SegmentValue(string id, long ts) =>
+        Encoding.UTF8.GetBytes($"{{\"id\":\"{id}\",\"ts\":{ts}}}");
+
+    // A shared segment is serialized with an empty envId that GetSegmentsAsync replaces with the
+    // actual envId at read time.
+    private static byte[] SharedSegmentValue(string id, long ts) =>
+        Encoding.UTF8.GetBytes($"{{\"id\":\"{id}\",\"envId\":\"\",\"ts\":{ts}}}");
+
+    private async Task SeedIndexAsync(Guid envId, string id, long score)
+    {
+        await _db.SortedSetAddAsync(RedisKeys.SegmentIndex(envId), id, score);
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_ByEnv_ReturnsCommittedVersion_NotUncommittedStaged()
+    {
+        // Arrange — gated path: two staged versions, pointer at 2000, index score 2000.
+        var envId = Guid.NewGuid();
+        var id = Guid.NewGuid().ToString();
+
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 1000), SegmentValue(id, 1000));
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 2000), SegmentValue(id, 2000));
+        await _db.StringSetAsync(RedisKeys.SegmentCommittedPointer(id), "2000");
+        await SeedIndexAsync(envId, id, 2000);
+
+        // Act — should resolve the pointer to v2000.
+        var committed = (await _sut.GetSegmentsAsync(envId, 0)).ToList();
+
+        // Assert
+        Assert.Single(committed);
+        Assert.Equal(SegmentValue(id, 2000), committed[0]);
+
+        // Arrange — stage a newer v3000 WITHOUT moving the pointer.
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 3000), SegmentValue(id, 3000));
+
+        // Act — must still return committed v2000, never the uncommitted staged v3000.
+        var stillCommitted = (await _sut.GetSegmentsAsync(envId, 0)).ToList();
+
+        // Assert
+        Assert.Single(stillCommitted);
+        Assert.Equal(SegmentValue(id, 2000), stillCommitted[0]);
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_ByEnv_FallsBackToMainKey_WhenNoPointer()
+    {
+        // Arrange — BestEffort path: only the legacy main key + index, no pointer.
+        var envId = Guid.NewGuid();
+        var id = Guid.NewGuid().ToString();
+        var mainValue = SegmentValue(id, 500);
+
+        await _db.StringSetAsync(RedisKeys.Segment(id), mainValue);
+        await SeedIndexAsync(envId, id, 500);
+
+        // Act
+        var result = (await _sut.GetSegmentsAsync(envId, 0)).ToList();
+
+        // Assert — unchanged behavior: returns the main-key value.
+        Assert.Single(result);
+        Assert.Equal(mainValue, result[0]);
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_ByEnv_ReplacesEmptyEnvId_ForCommittedSharedSegment()
+    {
+        // Arrange — gated path with a shared segment (empty envId) as the committed version.
+        var envId = Guid.NewGuid();
+        var id = Guid.NewGuid().ToString();
+
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 2000), SharedSegmentValue(id, 2000));
+        await _db.StringSetAsync(RedisKeys.SegmentCommittedPointer(id), "2000");
+        await SeedIndexAsync(envId, id, 2000);
+
+        // Act
+        var result = (await _sut.GetSegmentsAsync(envId, 0)).ToList();
+
+        // Assert — empty envId replaced with the actual envId on the committed versioned value.
+        Assert.Single(result);
+        var expected = Encoding.UTF8.GetBytes($"{{\"id\":\"{id}\",\"envId\":\"{envId}\",\"ts\":2000}}");
+        Assert.Equal(expected, result[0]);
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_ByEnv_ReplacesEmptyEnvId_ForMainKeySharedSegment()
+    {
+        // Arrange — BestEffort path with a shared segment (empty envId) on the main key.
+        var envId = Guid.NewGuid();
+        var id = Guid.NewGuid().ToString();
+
+        await _db.StringSetAsync(RedisKeys.Segment(id), SharedSegmentValue(id, 500));
+        await SeedIndexAsync(envId, id, 500);
+
+        // Act
+        var result = (await _sut.GetSegmentsAsync(envId, 0)).ToList();
+
+        // Assert — empty envId replaced with the actual envId (unchanged behavior).
+        Assert.Single(result);
+        var expected = Encoding.UTF8.GetBytes($"{{\"id\":\"{id}\",\"envId\":\"{envId}\",\"ts\":500}}");
+        Assert.Equal(expected, result[0]);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_ReturnsCommittedVersion_NotUncommittedStaged()
+    {
+        // Arrange
+        var id = Guid.NewGuid().ToString();
+
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 1000), SegmentValue(id, 1000));
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 2000), SegmentValue(id, 2000));
+        await _db.StringSetAsync(RedisKeys.SegmentCommittedPointer(id), "2000");
+        await _db.StringSetAsync(RedisKeys.SegmentVersion(id, 3000), SegmentValue(id, 3000));
+
+        // Act
+        var result = await _sut.GetSegmentAsync(id);
+
+        // Assert — committed v2000, not staged v3000.
+        Assert.Equal(SegmentValue(id, 2000), result);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_FallsBackToMainKey_WhenNoPointer()
+    {
+        // Arrange
+        var id = Guid.NewGuid().ToString();
+        var mainValue = SegmentValue(id, 500);
+        await _db.StringSetAsync(RedisKeys.Segment(id), mainValue);
+
+        // Act
+        var result = await _sut.GetSegmentAsync(id);
+
+        // Assert
+        Assert.Equal(mainValue, result);
+    }
+
+    public void Dispose()
+    {
+        _redisClient.Connection.Dispose();
+    }
+}


### PR DESCRIPTION
Closes #21. The segment analog of D2 (#19) — the last non-optional item. Without it, gated **segment** commits served stale values on SDK full/incremental sync + reconnect, because `CommitSegmentAsync` advances the segment pointer + index but not the main `featbit:segment:{id}` key, while `RedisStore` read that main key.

`GetSegmentsAsync` + `GetSegmentAsync` now: GET `segment-committed:{id}`; if present → read `segment:{id}:v{pointer}`; else → fall back to the legacy main key. Batched (pointer GETs then value GETs), mirroring the flag path. The shared-segment `envId` post-processing is preserved and applies to either source.

(The other half of the original D4 — the segment *consumer* 'notify-then-read' — is obsolete under Model A, same as D3/#20.)

**Verification (real Redis :6393):** 6 new segment tests (gated returns v2000 even with uncommitted v3000 staged; BestEffort fallback; shared-segment replacement — for both read methods) + the 4 existing D2 flag tests still green; eval-server build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)