### PR TITLE
🧹 Pending-change audit-field + nested-pending cleanup (#35)

### DIFF
--- a/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
+++ b/modules/back-end/src/Domain/FeatureFlags/FeatureFlag.cs
@@ -332,6 +332,14 @@ public class FeatureFlag : FullAuditedEntity
     /// </summary>
     public void SetPending(FeatureFlag pendingValue, long version)
     {
+        // A pending value must never itself carry a pending change (no pending-within-pending):
+        // the staged payload describes a single committed-to-be state, so null out any nested
+        // pending before storing it. This keeps the staged document flat and avoids recursive bloat.
+        if (pendingValue != null)
+        {
+            pendingValue.Pending = null;
+        }
+
         Pending = new PendingFlagChange
         {
             Version = version,
@@ -368,6 +376,15 @@ public class FeatureFlag : FullAuditedEntity
         ExptIncludeAllTargets = promoted.ExptIncludeAllTargets;
         Tags = promoted.Tags;
         IsArchived = promoted.IsArchived;
+        // Revision is part of the committed-relevant state (it changes on every mutation and is
+        // observed by evaluators); adopt the pending value's revision on promotion.
+        Revision = promoted.Revision;
+
+        // Refresh audit fields so the committed value reflects WHEN it was promoted and WHO authored
+        // the change. The promotion is the moment this value becomes authoritative, so UpdatedAt must
+        // advance to now; carry the pending author's UpdatorId.
+        UpdatorId = promoted.UpdatorId;
+        UpdatedAt = DateTime.UtcNow;
 
         CommittedVersion = version;
         Pending = null;

--- a/modules/back-end/src/Domain/Segments/Segment.cs
+++ b/modules/back-end/src/Domain/Segments/Segment.cs
@@ -188,6 +188,14 @@ public class Segment : AuditedEntity
     /// </summary>
     public void SetPending(Segment pendingValue, long version)
     {
+        // A pending value must never itself carry a pending change (no pending-within-pending):
+        // the staged payload describes a single committed-to-be state, so null out any nested
+        // pending before storing it. This keeps the staged document flat and avoids recursive bloat.
+        if (pendingValue != null)
+        {
+            pendingValue.Pending = null;
+        }
+
         Pending = new PendingSegmentChange
         {
             Version = version,
@@ -221,6 +229,11 @@ public class Segment : AuditedEntity
         Rules = promoted.Rules;
         Tags = promoted.Tags;
         IsArchived = promoted.IsArchived;
+
+        // Refresh the audit timestamp so the committed value reflects WHEN it was promoted: the
+        // promotion is the moment this value becomes authoritative. (Segment is an AuditedEntity
+        // with no UpdatorId, so only UpdatedAt is carried.)
+        UpdatedAt = DateTime.UtcNow;
 
         CommittedVersion = version;
         Pending = null;

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/FeatureFlagService.cs
@@ -157,6 +157,13 @@ public class FeatureFlagService : MongoDbService<FeatureFlag>, IFeatureFlagServi
         // ensure the flag exists (committed value is left untouched)
         await GetAsync(envId, key);
 
+        // A pending value must never itself carry a pending change (no pending-within-pending);
+        // null it out to keep the staged document flat (mirrors FeatureFlag.SetPending).
+        if (pendingValue != null)
+        {
+            pendingValue.Pending = null;
+        }
+
         var pending = new PendingFlagChange
         {
             Version = version,

--- a/modules/back-end/src/Infrastructure/Services/MongoDb/SegmentService.cs
+++ b/modules/back-end/src/Infrastructure/Services/MongoDb/SegmentService.cs
@@ -194,6 +194,13 @@ public class SegmentService(MongoDbClient mongoDb, ILogger<SegmentService> logge
         // ensure the segment exists (committed value is left untouched)
         await GetAsync(id);
 
+        // A pending value must never itself carry a pending change (no pending-within-pending);
+        // null it out to keep the staged document flat (mirrors Segment.SetPending).
+        if (pendingValue != null)
+        {
+            pendingValue.Pending = null;
+        }
+
         var pending = new PendingSegmentChange
         {
             Version = version,

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingPostgresTests.cs
@@ -262,4 +262,50 @@ public sealed class FeatureFlagCommittedPendingPostgresTests : IAsyncLifetime
         Assert.Equal(4, raw.Pending!.Version);
         Assert.True(raw.Pending.Value.IsEnabled);
     }
+
+    [Fact]
+    public async Task Promote_Refreshes_Audit_Fields_On_Committed_Value()
+    {
+        // #35: promotion must refresh the committed value's audit fields so UpdatedAt reflects WHEN
+        // it became authoritative and UpdatorId reflects WHO authored the pending change.
+        const string key = "b4-promote-audit";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        var staleTime = DateTime.UtcNow.AddDays(-7);
+        committed.UpdatedAt = staleTime;
+        committed.UpdatorId = Guid.NewGuid();
+        await _sut.AddOneAsync(committed);
+
+        var pendingAuthor = Guid.NewGuid();
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        pendingValue.UpdatorId = pendingAuthor;
+        await _sut.SetPendingAsync(_envId, key, pendingValue, version: 2);
+
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 2);
+        Assert.True(promoted);
+
+        var afterPromote = await _sut.GetCommittedAsync(_envId, key);
+        Assert.True(afterPromote.UpdatedAt > staleTime);
+        Assert.Equal(pendingAuthor, afterPromote.UpdatorId);
+    }
+
+    [Fact]
+    public async Task SetPending_Strips_Nested_Pending_From_Staged_Value()
+    {
+        // #35: a pending value must never itself carry a (nested) pending change.
+        const string key = "b4-no-nested-pending";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        pendingValue.SetPending(CreateFlag(key, isEnabled: false), version: 99);
+        Assert.NotNull(pendingValue.Pending);
+
+        await _sut.SetPendingAsync(_envId, key, pendingValue, version: 2);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Null(raw.Pending!.Value.Pending);
+    }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/FeatureFlags/FeatureFlagCommittedPendingTests.cs
@@ -225,4 +225,52 @@ public sealed class FeatureFlagCommittedPendingTests : IAsyncLifetime
         Assert.Equal(4, raw.Pending!.Version);
         Assert.True(raw.Pending.Value.IsEnabled);
     }
+
+    [Fact]
+    public async Task Promote_Refreshes_Audit_Fields_On_Committed_Value()
+    {
+        // #35: promotion must refresh the committed value's audit fields so UpdatedAt reflects WHEN
+        // it became authoritative and UpdatorId reflects WHO authored the pending change.
+        const string key = "b3-promote-audit";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        // force a clearly-stale committed timestamp/author so the refresh is observable
+        var staleTime = DateTime.UtcNow.AddDays(-7);
+        committed.UpdatedAt = staleTime;
+        committed.UpdatorId = Guid.NewGuid();
+        await _sut.AddOneAsync(committed);
+
+        var pendingAuthor = Guid.NewGuid();
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        pendingValue.UpdatorId = pendingAuthor;
+        await _sut.SetPendingAsync(_envId, key, pendingValue, version: 2);
+
+        var promoted = await _sut.PromotePendingAsync(_envId, key, expectedVersion: 2);
+        Assert.True(promoted);
+
+        var afterPromote = await _sut.GetCommittedAsync(_envId, key);
+        Assert.True(afterPromote.UpdatedAt > staleTime);
+        Assert.Equal(pendingAuthor, afterPromote.UpdatorId);
+    }
+
+    [Fact]
+    public async Task SetPending_Strips_Nested_Pending_From_Staged_Value()
+    {
+        // #35: a pending value must never itself carry a (nested) pending change.
+        const string key = "b3-no-nested-pending";
+        var committed = CreateFlag(key, isEnabled: false);
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateFlag(key, isEnabled: true);
+        // attach a bogus nested pending that must be stripped on stage
+        pendingValue.SetPending(CreateFlag(key, isEnabled: false), version: 99);
+        Assert.NotNull(pendingValue.Pending);
+
+        await _sut.SetPendingAsync(_envId, key, pendingValue, version: 2);
+
+        var raw = await _sut.GetAsync(_envId, key);
+        Assert.NotNull(raw.Pending);
+        Assert.Null(raw.Pending!.Value.Pending);
+    }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingPostgresTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingPostgresTests.cs
@@ -277,4 +277,44 @@ public sealed class SegmentCommittedPendingPostgresTests : IAsyncLifetime
         Assert.Equal(2, all.Count);
         Assert.All(all, s => Assert.Null(s.Pending));
     }
+
+    [Fact]
+    public async Task Promote_Refreshes_UpdatedAt_On_Committed_Value()
+    {
+        // #35: promotion must refresh the committed value's UpdatedAt so it reflects WHEN the value
+        // became authoritative. (Segment is an AuditedEntity with no UpdatorId.)
+        var committed = CreateSegment("s1-promote-audit", "old");
+        committed.CommittedVersion = 1;
+        var staleTime = DateTime.UtcNow.AddDays(-7);
+        committed.UpdatedAt = staleTime;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-promote-audit", "new"), version: 2);
+
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 2);
+        Assert.True(promoted);
+
+        var afterPromote = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("new", afterPromote.Description);
+        Assert.True(afterPromote.UpdatedAt > staleTime);
+    }
+
+    [Fact]
+    public async Task SetPending_Strips_Nested_Pending_From_Staged_Value()
+    {
+        // #35: a pending value must never itself carry a (nested) pending change.
+        var committed = CreateSegment("s1-no-nested-pending", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateSegment("s1-no-nested-pending", "new");
+        pendingValue.SetPending(CreateSegment("s1-no-nested-pending", "bogus"), version: 99);
+        Assert.NotNull(pendingValue.Pending);
+
+        await _sut.SetPendingAsync(committed.Id, pendingValue, version: 2);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Null(raw.Pending!.Value.Pending);
+    }
 }

--- a/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingTests.cs
+++ b/modules/back-end/tests/Application.IntegrationTests/Segments/SegmentCommittedPendingTests.cs
@@ -240,4 +240,44 @@ public sealed class SegmentCommittedPendingTests : IAsyncLifetime
         Assert.Equal(2, all.Count);
         Assert.All(all, s => Assert.Null(s.Pending));
     }
+
+    [Fact]
+    public async Task Promote_Refreshes_UpdatedAt_On_Committed_Value()
+    {
+        // #35: promotion must refresh the committed value's UpdatedAt so it reflects WHEN the value
+        // became authoritative. (Segment is an AuditedEntity with no UpdatorId.)
+        var committed = CreateSegment("s1-promote-audit", "old");
+        committed.CommittedVersion = 1;
+        var staleTime = DateTime.UtcNow.AddDays(-7);
+        committed.UpdatedAt = staleTime;
+        await _sut.AddOneAsync(committed);
+
+        await _sut.SetPendingAsync(committed.Id, CreateSegment("s1-promote-audit", "new"), version: 2);
+
+        var promoted = await _sut.PromotePendingAsync(committed.Id, expectedVersion: 2);
+        Assert.True(promoted);
+
+        var afterPromote = await _sut.GetCommittedAsync(committed.Id);
+        Assert.Equal("new", afterPromote.Description);
+        Assert.True(afterPromote.UpdatedAt > staleTime);
+    }
+
+    [Fact]
+    public async Task SetPending_Strips_Nested_Pending_From_Staged_Value()
+    {
+        // #35: a pending value must never itself carry a (nested) pending change.
+        var committed = CreateSegment("s1-no-nested-pending", "old");
+        committed.CommittedVersion = 1;
+        await _sut.AddOneAsync(committed);
+
+        var pendingValue = CreateSegment("s1-no-nested-pending", "new");
+        pendingValue.SetPending(CreateSegment("s1-no-nested-pending", "bogus"), version: 99);
+        Assert.NotNull(pendingValue.Pending);
+
+        await _sut.SetPendingAsync(committed.Id, pendingValue, version: 2);
+
+        var raw = await _sut.GetAsync(committed.Id);
+        Assert.NotNull(raw.Pending);
+        Assert.Null(raw.Pending!.Value.Pending);
+    }
 }


### PR DESCRIPTION
Closes #35 (the high-value, low-risk parts).

- **Audit fields on promote (the real bug):** `FeatureFlag.PromotePending` refreshes `UpdatedAt` (UTC) + carries `UpdatorId`; `Segment.PromotePending` refreshes `UpdatedAt` (no UpdatorId on Segment). Previously a promotion left stale audit timestamps on the committed value.
- **No nested pending:** `SetPending` (domain + the Mongo services that build the pending inline) nulls `pendingValue.Pending`.
- **Curated copy list:** added missing `Revision` to flag promote (changes on every update, observed by evaluators); segment list already complete.
- **Deferred (documented):** slimming `Pending.Value` off the full entity type — the staged Redis value + jsonb serialization make it not low-risk; left as the entity.

**Verification (real Mongo + Postgres):** 40 committed/pending tests incl. 8 new (refreshed UpdatedAt for flags+segments × Mongo+Postgres; no-nested-pending); full back-end suite 233/233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)