### PR TITLE
🏗 QA GatedCommit enablement (config wiring, #25)

### DIFF
--- a/control-plane-qa/01-Infrastructure/Deploy-FeatBitClusters.ps1
+++ b/control-plane-qa/01-Infrastructure/Deploy-FeatBitClusters.ps1
@@ -1668,6 +1668,20 @@ foreach ($clusterContext in @("west", "east")) {
         Write-Warning "Failed to set Kafka config on evaluation-server in $clusterContext"
     }
 
+    # Cross-DC consistency (gated commit): the eval server must report its DC
+    # identity so the control plane can build the per-DC live set and gate commits.
+    # DcId = cluster name ("west"/"east"); MUST match the control-plane Redis DcId.
+    $consistencyMode = if ($env:CONSISTENCY_MODE -eq 'GatedCommit') { 'GatedCommit' } else { 'BestEffort' }
+    if ($consistencyMode -eq 'GatedCommit') {
+        kubectl --context $clusterContext -n featbit set env deployment/evaluation-server `
+            "ControlPlane__ConsistencyMode=GatedCommit" `
+            "ControlPlane__DcId=$clusterContext" `
+            "ControlPlane__Region=$clusterContext" | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to set consistency (DcId) config on evaluation-server in $clusterContext"
+        }
+    }
+
     # Scale evaluation-server to 3 replicas so cp09 can exercise intra-cluster
     # failover (kill one pod, observe clients re-roll to surviving pods in
     # the same cluster via the host nginx LB) in addition to cross-cluster
@@ -1686,19 +1700,50 @@ Write-Info "Configuring cross-cluster Redis instances on control-plane deploymen
 # the remote cluster's Redis reached via the host port-forward on host.minikube.internal.
 #   West control-plane → east Redis on host port 6380
 #   East control-plane → west Redis on host port 6379
-kubectl --context west -n featbit set env deployment/control-plane `
-    "Redis__Instances__0=redis:6379" `
-    "Redis__Instances__1=${CrossClusterRedisHost}:6380" | Out-Null
-if ($LASTEXITCODE -ne 0) {
-    Write-Warning "Failed to set Redis cross-cluster instance on control-plane in west"
+$consistencyMode = if ($env:CONSISTENCY_MODE -eq 'GatedCommit') { 'GatedCommit' } else { 'BestEffort' }
+if ($consistencyMode -eq 'GatedCommit') {
+    # GatedCommit: label each Redis instance with its DcId — the join key the commit
+    # coordinator uses to correlate a DC's Redis with that DC's eval-server leases.
+    # Object-form keys (__ConnectionString / __DcId) are REQUIRED to bind to
+    # RedisInstanceConfig. Each DcId MUST equal that cluster's eval-server
+    # ControlPlane__DcId (the cluster name, set in the per-cluster loop above).
+    #   west control-plane: 0 = local west redis (DcId=west), 1 = remote east redis (DcId=east)
+    #   east control-plane: 0 = local east redis (DcId=east), 1 = remote west redis (DcId=west)
+    kubectl --context west -n featbit set env deployment/control-plane `
+        "ControlPlane__ConsistencyMode=GatedCommit" `
+        "Redis__Instances__0__ConnectionString=redis:6379" `
+        "Redis__Instances__0__DcId=west" `
+        "Redis__Instances__1__ConnectionString=${CrossClusterRedisHost}:6380" `
+        "Redis__Instances__1__DcId=east" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to set gated-commit Redis/DcId config on control-plane in west"
+    }
+    kubectl --context east -n featbit set env deployment/control-plane `
+        "ControlPlane__ConsistencyMode=GatedCommit" `
+        "Redis__Instances__0__ConnectionString=redis:6379" `
+        "Redis__Instances__0__DcId=east" `
+        "Redis__Instances__1__ConnectionString=${CrossClusterRedisHost}:6379" `
+        "Redis__Instances__1__DcId=west" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to set gated-commit Redis/DcId config on control-plane in east"
+    }
+    Write-Success "GatedCommit: cross-cluster Redis labeled with DcIds (west 0=west/1=east, east 0=east/1=west); ConsistencyMode=GatedCommit on both control planes + eval servers"
 }
-kubectl --context east -n featbit set env deployment/control-plane `
-    "Redis__Instances__0=redis:6379" `
-    "Redis__Instances__1=${CrossClusterRedisHost}:6379" | Out-Null
-if ($LASTEXITCODE -ne 0) {
-    Write-Warning "Failed to set Redis cross-cluster instance on control-plane in east"
+else {
+    kubectl --context west -n featbit set env deployment/control-plane `
+        "Redis__Instances__0=redis:6379" `
+        "Redis__Instances__1=${CrossClusterRedisHost}:6380" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to set Redis cross-cluster instance on control-plane in west"
+    }
+    kubectl --context east -n featbit set env deployment/control-plane `
+        "Redis__Instances__0=redis:6379" `
+        "Redis__Instances__1=${CrossClusterRedisHost}:6379" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to set Redis cross-cluster instance on control-plane in east"
+    }
+    Write-Success "Cross-cluster Redis configured (west→east: ${CrossClusterRedisHost}:6380, east→west: ${CrossClusterRedisHost}:6379)"
 }
-Write-Success "Cross-cluster Redis configured (west→east: ${CrossClusterRedisHost}:6380, east→west: ${CrossClusterRedisHost}:6379)"
 
 Write-Info "Waiting 45 seconds for application pods to pull images and start..."
 Start-Sleep -Seconds 45

--- a/control-plane-qa/01-Infrastructure/deployment.env.example
+++ b/control-plane-qa/01-Infrastructure/deployment.env.example
@@ -147,6 +147,17 @@
 # EAST_CPUS=4
 # EAST_MEMORY=8192
 
+# ─── Cross-DC Consistency (gated commit) ──────────────────────────────────────
+#
+# Controls the control-plane gated-commit consistency mode (see
+# 00-Docs/GATED-COMMIT-CONSISTENCY.md). Default BestEffort = unchanged behavior.
+# Set to GatedCommit to enable: a flag/segment change is not served by any live
+# DC until every live DC has it. When GatedCommit, the deploy additionally labels
+# each control-plane Redis instance with its DcId and sets each eval server's
+# ControlPlane__DcId to match (the cluster name "west"/"east" is used as the DcId).
+#
+# CONSISTENCY_MODE=BestEffort
+
 # ─── Certificate Trust ────────────────────────────────────────────────────────
 #
 # Semicolon-separated list of corporate certificates to trust inside each


### PR DESCRIPTION
The **config-wiring** half of #25 (the east/west *validation run* remains your manual step — checklist in `00-Docs/GATED-COMMIT-CONSISTENCY.md`). #25 stays open until that passes.

- New `CONSISTENCY_MODE` toggle in `deployment.env.example` (default **BestEffort** → deploy is byte-for-byte unchanged; the entire change is gated behind `GatedCommit`).
- When `GatedCommit`, `Deploy-FeatBitClusters.ps1`:
  - labels each control-plane Redis instance with its **DcId** using object-form keys (`Redis__Instances__N__ConnectionString` / `__DcId`) — west: 0=west/1=east, east: 0=east/1=west;
  - sets each eval server's `ControlPlane__DcId`/`Region` to the cluster name + `ConsistencyMode=GatedCommit`, so the Redis DcIds match the lease DcIds (the join key).

### ⚠️ Verification limits (honest)
- PowerShell **parses cleanly** (validated). But I **cannot run the minikube east/west deploy from here**, so the GatedCommit path is **unvalidated against real clusters** — please confirm on a deploy.
- Two things to watch when you run it: (1) the existing `Redis__Instances__0=redis:6379` scalar form does **not** bind to `RedisInstanceConfig` (no `__ConnectionString`/`DcId`) — the GatedCommit path switches to object form, which is the riskiest bit to confirm; (2) `kubectl set env` adds vars without removing the old scalar `Redis__Instances__N` — on a re-deploy over a prior BestEffort deployment you may need to unset those (a fresh deploy is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)