### PR TITLE
✨ Hard readiness fence on stale heartbeats (D5, #22)

### DIFF
--- a/modules/evaluation-server/src/Api/Health/HeartbeatFreshnessHealthCheck.cs
+++ b/modules/evaluation-server/src/Api/Health/HeartbeatFreshnessHealthCheck.cs
@@ -16,21 +16,21 @@ namespace Api.Health;
 /// is irrelevant when changes are not cross-DC gated.</item>
 /// <item><b>GatedCommit</b> — when the pod has been unable to publish a heartbeat for longer than
 /// <c>ControlPlane:HeartbeatStalenessThresholdSeconds</c> (it has likely been evicted / partitioned
-/// from the control plane), report <see cref="HealthStatus.Degraded"/> — NOT
-/// <see cref="HealthStatus.Unhealthy"/>. The pod keeps serving its consistent last-committed values;
-/// we surface degradation for operators rather than pulling it from rotation.</item>
+/// from the control plane), report <see cref="HealthStatus.Unhealthy"/> — a HARD readiness fence.</item>
 /// </list>
 /// </para>
 /// <para>
-/// <b>Readiness:</b> the ASP.NET Core health middleware maps both <c>Healthy</c> and <c>Degraded</c>
-/// to HTTP 200 by default (only <c>Unhealthy</c> → 503), and the eval-server readiness endpoint does
-/// not override that mapping. Therefore a <c>Degraded</c> result keeps <c>/health/readiness</c>
-/// passing — this check is observational, NOT a hard readiness fence.
+/// <b>Readiness (hard fence):</b> the ASP.NET Core health middleware maps <c>Unhealthy</c> to HTTP 503,
+/// so this check is tagged for <c>/health/readiness</c> and an <c>Unhealthy</c> result FAILS readiness —
+/// the pod is pulled from load-balancer rotation. This is the strict consistency-over-availability
+/// choice: a partitioned/evicted DC's eval servers stop serving entirely rather than serving
+/// stale-but-consistent values. It is tagged Readiness only (NOT liveness), so the pod is removed from
+/// rotation, not restarted; it returns to rotation once heartbeats resume.
 /// </para>
 /// <para>
 /// Also emits the <c>evaluation_server.consistency.heartbeat_staleness_seconds</c> observable gauge
 /// (seconds since last successful publish; 0 when healthy) and logs a warning on the transition into
-/// degraded.
+/// the unhealthy/fenced state.
 /// </para>
 /// </remarks>
 public sealed class HeartbeatFreshnessHealthCheck : IHealthCheck
@@ -157,22 +157,22 @@ public sealed class HeartbeatFreshnessHealthCheck : IHealthCheck
         var message = lastSuccess.HasValue
             ? $"Heartbeat stale: DcId={dcId} has not published a heartbeat for {ageSeconds}s " +
               $"(threshold {thresholdSeconds}s); pod likely evicted/partitioned from the control " +
-              "plane. Serving last-committed values."
+              "plane. Failing readiness (pulled from rotation)."
             : $"No heartbeat published since startup: DcId={dcId}, {ageSeconds}s since start " +
-              $"(threshold {thresholdSeconds}s); pod cannot reach the control plane. Serving " +
-              "last-committed values.";
+              $"(threshold {thresholdSeconds}s); pod cannot reach the control plane. Failing " +
+              "readiness (pulled from rotation).";
 
-        // Log a warning only on the transition into degraded to avoid log spam.
+        // Log a warning only on the transition into the fenced state to avoid log spam.
         if (Interlocked.Exchange(ref _wasDegraded, 1) == 0)
         {
             _logger.LogWarning(
-                "Heartbeat freshness degraded: DcId={DcId}, StalenessSeconds={StalenessSeconds}, " +
+                "Heartbeat freshness unhealthy: DcId={DcId}, StalenessSeconds={StalenessSeconds}, " +
                 "ThresholdSeconds={ThresholdSeconds}. Pod likely evicted/partitioned from the " +
-                "control plane; continuing to serve last-committed values.",
+                "control plane; failing readiness to pull it from rotation.",
                 dcId, ageSeconds, thresholdSeconds);
         }
 
-        return Task.FromResult(HealthCheckResult.Degraded(message));
+        return Task.FromResult(HealthCheckResult.Unhealthy(message));
     }
 
     private int GetThresholdSeconds()

--- a/modules/evaluation-server/src/Api/Health/HeartbeatFreshnessHealthCheck.cs
+++ b/modules/evaluation-server/src/Api/Health/HeartbeatFreshnessHealthCheck.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics.Metrics;
+using Api.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Api.Health;
+
+/// <summary>
+/// D5 (#22) self-fence / readiness signal. Reports whether this evaluation-server pod is still
+/// able to publish heartbeats to the control plane.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Behavior is mode-dependent:
+/// <list type="bullet">
+/// <item><b>BestEffort</b> — no-op: always <see cref="HealthStatus.Healthy"/>. Heartbeat freshness
+/// is irrelevant when changes are not cross-DC gated.</item>
+/// <item><b>GatedCommit</b> — when the pod has been unable to publish a heartbeat for longer than
+/// <c>ControlPlane:HeartbeatStalenessThresholdSeconds</c> (it has likely been evicted / partitioned
+/// from the control plane), report <see cref="HealthStatus.Degraded"/> — NOT
+/// <see cref="HealthStatus.Unhealthy"/>. The pod keeps serving its consistent last-committed values;
+/// we surface degradation for operators rather than pulling it from rotation.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Readiness:</b> the ASP.NET Core health middleware maps both <c>Healthy</c> and <c>Degraded</c>
+/// to HTTP 200 by default (only <c>Unhealthy</c> → 503), and the eval-server readiness endpoint does
+/// not override that mapping. Therefore a <c>Degraded</c> result keeps <c>/health/readiness</c>
+/// passing — this check is observational, NOT a hard readiness fence.
+/// </para>
+/// <para>
+/// Also emits the <c>evaluation_server.consistency.heartbeat_staleness_seconds</c> observable gauge
+/// (seconds since last successful publish; 0 when healthy) and logs a warning on the transition into
+/// degraded.
+/// </para>
+/// </remarks>
+public sealed class HeartbeatFreshnessHealthCheck : IHealthCheck
+{
+    /// <summary>
+    /// Stable meter name for evaluation-server consistency observability. Mirrors the control
+    /// plane's <c>FeatBit.ControlPlane.Consistency</c> meter naming.
+    /// </summary>
+    public const string MeterName = "FeatBit.EvaluationServer.Consistency";
+
+    /// <summary>
+    /// Seconds since this pod last successfully published a heartbeat (0 when fresh / healthy /
+    /// not applicable). Operators alert on a sustained non-zero value under GatedCommit.
+    /// </summary>
+    public const string StalenessGaugeName = "evaluation_server.consistency.heartbeat_staleness_seconds";
+
+    /// <summary>
+    /// Default staleness threshold (seconds) when <c>ControlPlane:HeartbeatStalenessThresholdSeconds</c>
+    /// is unset / non-positive. 180s = 3× the default 60s heartbeat interval, i.e. several missed
+    /// heartbeats — long enough to avoid flapping on a single transient publish failure.
+    /// </summary>
+    public const int DefaultStalenessThresholdSeconds = 180;
+
+    private static readonly Meter Meter = new(MeterName);
+
+    // Most recent staleness (seconds), refreshed on every health-check evaluation. Static + volatile
+    // so a single gauge registration survives across check instances and the gauge callback may run
+    // on a different thread than the check evaluation.
+    private static volatile int _stalenessSeconds;
+
+    private static readonly ObservableGauge<long> StalenessGauge = Meter.CreateObservableGauge(
+        StalenessGaugeName,
+        () => (long)_stalenessSeconds,
+        unit: "s",
+        description:
+        "Seconds since this evaluation-server pod last successfully published a heartbeat to the " +
+        "control plane; 0 when healthy / not applicable (BestEffort).");
+
+    private readonly IHeartbeatPublishStatus _status;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<HeartbeatFreshnessHealthCheck> _logger;
+    private readonly Func<DateTimeOffset> _now;
+    private readonly DateTimeOffset _startedAt;
+
+    // Tracks the previous degraded state so the warning is logged only on the transition into
+    // degraded (not on every poll while degraded persists).
+    private int _wasDegraded;
+
+    public HeartbeatFreshnessHealthCheck(
+        IHeartbeatPublishStatus status,
+        IConfiguration configuration,
+        ILogger<HeartbeatFreshnessHealthCheck> logger)
+        : this(status, configuration, logger, now: null)
+    {
+    }
+
+    /// <summary>
+    /// Testable constructor: <paramref name="now"/> injects the clock so freshness can be exercised
+    /// without timers. When <paramref name="now"/> is supplied, the startup-grace baseline is the
+    /// first value it returns.
+    /// </summary>
+    internal HeartbeatFreshnessHealthCheck(
+        IHeartbeatPublishStatus status,
+        IConfiguration configuration,
+        ILogger<HeartbeatFreshnessHealthCheck> logger,
+        Func<DateTimeOffset>? now)
+    {
+        _status = status;
+        _configuration = configuration;
+        _logger = logger;
+        _now = now ?? (() => DateTimeOffset.UtcNow);
+        _startedAt = _now();
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // BestEffort: heartbeat freshness is irrelevant — always healthy, gauge stays at 0.
+        if (_configuration.GetConsistencyMode() != ConsistencyMode.GatedCommit)
+        {
+            _stalenessSeconds = 0;
+            return Task.FromResult(HealthCheckResult.Healthy(
+                "Heartbeat freshness not gating (BestEffort)."));
+        }
+
+        var thresholdSeconds = GetThresholdSeconds();
+        var threshold = TimeSpan.FromSeconds(thresholdSeconds);
+        var now = _now();
+        var dcId = _configuration.GetDcId() ?? "(unset)";
+
+        var lastSuccess = _status.LastSuccessfulPublishAt;
+
+        TimeSpan age;
+        if (lastSuccess.HasValue)
+        {
+            age = now - lastSuccess.Value;
+        }
+        else
+        {
+            // Never published since startup: measure from process start so a just-started pod gets
+            // a startup grace equal to the threshold before it can be considered stale.
+            age = now - _startedAt;
+        }
+
+        var ageSeconds = (int)Math.Max(0, age.TotalSeconds);
+        _stalenessSeconds = ageSeconds;
+
+        var isStale = age > threshold;
+
+        if (!isStale)
+        {
+            Interlocked.Exchange(ref _wasDegraded, 0);
+
+            var healthyMessage = lastSuccess.HasValue
+                ? $"Heartbeat fresh: DcId={dcId}, {ageSeconds}s since last successful publish " +
+                  $"(threshold {thresholdSeconds}s)."
+                : $"Within startup grace: DcId={dcId}, {ageSeconds}s since start " +
+                  $"(threshold {thresholdSeconds}s).";
+
+            return Task.FromResult(HealthCheckResult.Healthy(healthyMessage));
+        }
+
+        var message = lastSuccess.HasValue
+            ? $"Heartbeat stale: DcId={dcId} has not published a heartbeat for {ageSeconds}s " +
+              $"(threshold {thresholdSeconds}s); pod likely evicted/partitioned from the control " +
+              "plane. Serving last-committed values."
+            : $"No heartbeat published since startup: DcId={dcId}, {ageSeconds}s since start " +
+              $"(threshold {thresholdSeconds}s); pod cannot reach the control plane. Serving " +
+              "last-committed values.";
+
+        // Log a warning only on the transition into degraded to avoid log spam.
+        if (Interlocked.Exchange(ref _wasDegraded, 1) == 0)
+        {
+            _logger.LogWarning(
+                "Heartbeat freshness degraded: DcId={DcId}, StalenessSeconds={StalenessSeconds}, " +
+                "ThresholdSeconds={ThresholdSeconds}. Pod likely evicted/partitioned from the " +
+                "control plane; continuing to serve last-committed values.",
+                dcId, ageSeconds, thresholdSeconds);
+        }
+
+        return Task.FromResult(HealthCheckResult.Degraded(message));
+    }
+
+    private int GetThresholdSeconds()
+    {
+        var configured = _configuration.GetValue<int>("ControlPlane:HeartbeatStalenessThresholdSeconds");
+        return configured > 0 ? configured : DefaultStalenessThresholdSeconds;
+    }
+}

--- a/modules/evaluation-server/src/Api/Health/HeartbeatService.cs
+++ b/modules/evaluation-server/src/Api/Health/HeartbeatService.cs
@@ -9,7 +9,8 @@ public class HeartbeatService(
     IMessageProducer messageProducer,
     ILogger<HeartbeatService> logger,
     IConfiguration configuration,
-    IAppliedWatermarkReader appliedWatermarkReader) : BackgroundService
+    IAppliedWatermarkReader appliedWatermarkReader,
+    IHeartbeatPublishStatus publishStatus) : BackgroundService
 {
     private readonly Guid _podId = InfrastructureInfo.Id;
 
@@ -23,7 +24,26 @@ public class HeartbeatService(
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            await messageProducer.PublishAsync(Topics.PodHeartbeat, await BuildHeartbeatAsync(stoppingToken));
+            try
+            {
+                await messageProducer.PublishAsync(Topics.PodHeartbeat, await BuildHeartbeatAsync(stoppingToken));
+
+                // D5 (#22): record a successful publish so HeartbeatFreshnessHealthCheck can detect
+                // when this pod can no longer reach the control plane.
+                publishStatus.MarkSuccess(DateTimeOffset.UtcNow);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Shutdown — stop the loop without recording a failure.
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Leave LastSuccessfulPublishAt unchanged: the freshness check measures age since the
+                // last successful publish, which is exactly what should grow while publishing fails.
+                publishStatus.MarkFailure(DateTimeOffset.UtcNow);
+                logger.LogWarning(ex, "HeartbeatService failed to publish heartbeat for PodId: {PodId}", _podId);
+            }
 
             await Task.Delay(heartbeatTimeSpan, stoppingToken);
         }

--- a/modules/evaluation-server/src/Api/Health/IHeartbeatPublishStatus.cs
+++ b/modules/evaluation-server/src/Api/Health/IHeartbeatPublishStatus.cs
@@ -1,0 +1,74 @@
+namespace Api.Health;
+
+/// <summary>
+/// D5 (#22) self-fence signal. A process-wide singleton recording when the
+/// <see cref="HeartbeatService"/> last managed to publish a heartbeat to the control plane.
+/// The <see cref="HeartbeatFreshnessHealthCheck"/> reads this to decide whether the pod has
+/// likely been evicted / partitioned from the control plane (no successful publish for longer
+/// than a threshold) and should report itself <c>Degraded</c> to operators.
+/// </summary>
+/// <remarks>
+/// This is an observational signal only. Under <c>GatedCommit</c> a stale heartbeat means the
+/// pod can no longer prove liveness to the control plane, but it keeps serving its
+/// last-committed (consistent) values — so we surface <c>Degraded</c>, never <c>Unhealthy</c>,
+/// and never fail readiness.
+/// </remarks>
+public interface IHeartbeatPublishStatus
+{
+    /// <summary>
+    /// Timestamp of the most recent successful heartbeat publish, or <c>null</c> if the pod has
+    /// not yet published a single heartbeat since startup.
+    /// </summary>
+    DateTimeOffset? LastSuccessfulPublishAt { get; }
+
+    /// <summary>
+    /// Records a successful heartbeat publish at <paramref name="at"/>, advancing
+    /// <see cref="LastSuccessfulPublishAt"/>.
+    /// </summary>
+    void MarkSuccess(DateTimeOffset at);
+
+    /// <summary>
+    /// Records a failed heartbeat publish. The last-success timestamp is intentionally left
+    /// unchanged so the freshness check measures age since the last <em>successful</em> publish.
+    /// </summary>
+    void MarkFailure(DateTimeOffset at);
+}
+
+/// <summary>
+/// Thread-safe default <see cref="IHeartbeatPublishStatus"/>. Registered as a singleton so the
+/// <see cref="HeartbeatService"/> (writer) and the <see cref="HeartbeatFreshnessHealthCheck"/>
+/// (reader) share the same instance.
+/// </summary>
+public sealed class HeartbeatPublishStatus : IHeartbeatPublishStatus
+{
+    private long _lastSuccessTicks;
+    private long _hasSucceeded;
+
+    /// <inheritdoc />
+    public DateTimeOffset? LastSuccessfulPublishAt
+    {
+        get
+        {
+            if (Interlocked.Read(ref _hasSucceeded) == 0)
+            {
+                return null;
+            }
+
+            var ticks = Interlocked.Read(ref _lastSuccessTicks);
+            return new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+
+    /// <inheritdoc />
+    public void MarkSuccess(DateTimeOffset at)
+    {
+        Interlocked.Exchange(ref _lastSuccessTicks, at.UtcTicks);
+        Interlocked.Exchange(ref _hasSucceeded, 1);
+    }
+
+    /// <inheritdoc />
+    public void MarkFailure(DateTimeOffset at)
+    {
+        // Intentionally no-op on the last-success timestamp: a failure must not refresh freshness.
+    }
+}

--- a/modules/evaluation-server/src/Api/Setup/ServicesRegister.cs
+++ b/modules/evaluation-server/src/Api/Setup/ServicesRegister.cs
@@ -29,7 +29,7 @@ public static class ServicesRegister
         services.AddSwaggerGen();
 
         // health check dependencies
-        services.AddHealthChecks().AddReadinessChecks(configuration);
+        var healthChecks = services.AddHealthChecks().AddReadinessChecks(configuration);
 
         // cors
         builder.AddCustomCors();
@@ -56,6 +56,16 @@ public static class ServicesRegister
 
         if (configuration.UseControlPlane())
         {
+            // D5 (#22): shared singleton recording the last successful heartbeat publish, plus the
+            // freshness health check that surfaces a Degraded (not Unhealthy) self-fence signal under
+            // GatedCommit. Tagged Readiness so it appears on /health/readiness; ASP.NET Core maps
+            // Degraded -> HTTP 200 by default (only Unhealthy -> 503), so a Degraded result is
+            // observational and does NOT fail readiness.
+            services.AddSingleton<IHeartbeatPublishStatus, HeartbeatPublishStatus>();
+            healthChecks.AddCheck<HeartbeatFreshnessHealthCheck>(
+                "heartbeat-freshness",
+                tags: new[] { HealthCheckBuilderExtensions.ReadinessTag });
+
             services.AddHostedService<HeartbeatService>();
         }
 

--- a/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatFreshnessHealthCheckTests.cs
+++ b/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatFreshnessHealthCheckTests.cs
@@ -1,0 +1,199 @@
+using Api.Health;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Application.IntegrationTests.Health;
+
+/// <summary>
+/// Pure unit tests for <see cref="HeartbeatFreshnessHealthCheck"/> (no infra). The clock and the
+/// publish-status singleton are injected so freshness can be exercised deterministically without
+/// timers.
+/// </summary>
+public class HeartbeatFreshnessHealthCheckTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 20, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class FakeClock(DateTimeOffset start)
+    {
+        private DateTimeOffset _now = start;
+
+        public DateTimeOffset Now() => _now;
+
+        public void Advance(TimeSpan by) => _now += by;
+    }
+
+    private static IConfiguration Config(params (string Key, string? Value)[] values)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(v => new KeyValuePair<string, string?>(v.Key, v.Value)))
+            .Build();
+
+    private static HeartbeatFreshnessHealthCheck CreateSut(
+        IConfiguration configuration,
+        IHeartbeatPublishStatus status,
+        FakeClock clock)
+        => new(
+            status,
+            configuration,
+            NullLogger<HeartbeatFreshnessHealthCheck>.Instance,
+            clock.Now);
+
+    private static Task<HealthCheckResult> Check(HeartbeatFreshnessHealthCheck sut)
+        => sut.CheckHealthAsync(new HealthCheckContext());
+
+    [Fact]
+    public async Task BestEffort_IsAlwaysHealthy_RegardlessOfHeartbeatAge()
+    {
+        var config = Config(
+            ("ControlPlane:ConsistencyMode", "BestEffort"),
+            ("ControlPlane:HeartbeatStalenessThresholdSeconds", "10"));
+        var status = new HeartbeatPublishStatus();
+        status.MarkSuccess(T0); // very stale relative to the clock below
+        var clock = new FakeClock(T0.AddHours(1));
+
+        var result = await Check(CreateSut(config, status, clock));
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task GatedCommit_Fresh_IsHealthy()
+    {
+        var config = Config(
+            ("ControlPlane:ConsistencyMode", "GatedCommit"),
+            ("ControlPlane:HeartbeatStalenessThresholdSeconds", "60"));
+        var clock = new FakeClock(T0);
+        var status = new HeartbeatPublishStatus();
+        status.MarkSuccess(T0);
+
+        clock.Advance(TimeSpan.FromSeconds(10)); // within threshold
+
+        var result = await Check(CreateSut(config, status, clock));
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task GatedCommit_Stale_IsDegraded_AndNamesDcIdAndAge()
+    {
+        var config = Config(
+            ("ControlPlane:ConsistencyMode", "GatedCommit"),
+            ("ControlPlane:DcId", "dc-west"),
+            ("ControlPlane:HeartbeatStalenessThresholdSeconds", "60"));
+        var clock = new FakeClock(T0);
+        var status = new HeartbeatPublishStatus();
+        status.MarkSuccess(T0);
+
+        clock.Advance(TimeSpan.FromSeconds(120)); // past the 60s threshold
+
+        var result = await Check(CreateSut(config, status, clock));
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("dc-west", result.Description);
+        Assert.Contains("120", result.Description);
+    }
+
+    [Fact]
+    public async Task GatedCommit_NeverPublished_WithinStartupGrace_IsHealthy()
+    {
+        var config = Config(
+            ("ControlPlane:ConsistencyMode", "GatedCommit"),
+            ("ControlPlane:HeartbeatStalenessThresholdSeconds", "60"));
+        var clock = new FakeClock(T0); // startedAt captured at T0
+        var status = new HeartbeatPublishStatus(); // never published
+
+        var sut = CreateSut(config, status, clock);
+        clock.Advance(TimeSpan.FromSeconds(30)); // still within startup grace (< 60s)
+
+        var result = await Check(sut);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task GatedCommit_NeverPublished_PastStartupGrace_IsDegraded()
+    {
+        var config = Config(
+            ("ControlPlane:ConsistencyMode", "GatedCommit"),
+            ("ControlPlane:DcId", "dc-east"),
+            ("ControlPlane:HeartbeatStalenessThresholdSeconds", "60"));
+        var clock = new FakeClock(T0);
+        var status = new HeartbeatPublishStatus(); // never published
+
+        var sut = CreateSut(config, status, clock);
+        clock.Advance(TimeSpan.FromSeconds(120)); // past startup grace
+
+        var result = await Check(sut);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("dc-east", result.Description);
+    }
+
+    [Fact]
+    public async Task GatedCommit_UsesDefaultThreshold_WhenUnset()
+    {
+        var config = Config(
+            ("ControlPlane:ConsistencyMode", "GatedCommit"));
+        var clock = new FakeClock(T0);
+        var status = new HeartbeatPublishStatus();
+        status.MarkSuccess(T0);
+
+        // Just under the documented default (180s) -> still healthy.
+        clock.Advance(TimeSpan.FromSeconds(HeartbeatFreshnessHealthCheck.DefaultStalenessThresholdSeconds - 1));
+        Assert.Equal(HealthStatus.Healthy, (await Check(CreateSut(config, status, clock))).Status);
+
+        // Past the default -> degraded.
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.Equal(HealthStatus.Degraded, (await Check(CreateSut(config, status, clock))).Status);
+    }
+
+    [Fact]
+    public void MarkFailure_DoesNotAdvanceLastSuccess()
+    {
+        var status = new HeartbeatPublishStatus();
+        status.MarkSuccess(T0);
+
+        status.MarkFailure(T0.AddSeconds(30));
+
+        Assert.Equal(T0, status.LastSuccessfulPublishAt);
+    }
+
+    [Fact]
+    public void LastSuccessfulPublishAt_IsNull_BeforeFirstSuccess()
+    {
+        var status = new HeartbeatPublishStatus();
+
+        Assert.Null(status.LastSuccessfulPublishAt);
+    }
+
+    /// <summary>
+    /// Readiness contract: ASP.NET Core's default health-result mapping treats
+    /// <see cref="HealthStatus.Degraded"/> as HTTP 200 (ready); only
+    /// <see cref="HealthStatus.Unhealthy"/> returns 503. The eval-server readiness endpoint does not
+    /// override that mapping (see <c>MiddlewaresRegister</c>), so a degraded heartbeat keeps
+    /// <c>/health/readiness</c> passing. This check must therefore NEVER return Unhealthy — it only
+    /// ever returns Healthy or Degraded — so it can never fail readiness.
+    /// </summary>
+    [Fact]
+    public async Task NeverReturnsUnhealthy_AcrossModesAndAges()
+    {
+        // BestEffort with a very stale heartbeat.
+        var bestEffort = Config(("ControlPlane:ConsistencyMode", "BestEffort"));
+        var s1 = new HeartbeatPublishStatus();
+        s1.MarkSuccess(T0);
+        Assert.NotEqual(
+            HealthStatus.Unhealthy,
+            (await Check(CreateSut(bestEffort, s1, new FakeClock(T0.AddHours(1))))).Status);
+
+        // GatedCommit, far past the threshold and never published — the worst case.
+        var gated = Config(
+            ("ControlPlane:ConsistencyMode", "GatedCommit"),
+            ("ControlPlane:HeartbeatStalenessThresholdSeconds", "30"));
+        var clock = new FakeClock(T0);
+        var sut = CreateSut(gated, new HeartbeatPublishStatus(), clock);
+        clock.Advance(TimeSpan.FromHours(1));
+        var result = await Check(sut);
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.NotEqual(HealthStatus.Unhealthy, result.Status);
+    }
+}

--- a/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatFreshnessHealthCheckTests.cs
+++ b/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatFreshnessHealthCheckTests.cs
@@ -74,7 +74,7 @@ public class HeartbeatFreshnessHealthCheckTests
     }
 
     [Fact]
-    public async Task GatedCommit_Stale_IsDegraded_AndNamesDcIdAndAge()
+    public async Task GatedCommit_Stale_IsUnhealthy_AndNamesDcIdAndAge()
     {
         var config = Config(
             ("ControlPlane:ConsistencyMode", "GatedCommit"),
@@ -88,7 +88,7 @@ public class HeartbeatFreshnessHealthCheckTests
 
         var result = await Check(CreateSut(config, status, clock));
 
-        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
         Assert.Contains("dc-west", result.Description);
         Assert.Contains("120", result.Description);
     }
@@ -111,7 +111,7 @@ public class HeartbeatFreshnessHealthCheckTests
     }
 
     [Fact]
-    public async Task GatedCommit_NeverPublished_PastStartupGrace_IsDegraded()
+    public async Task GatedCommit_NeverPublished_PastStartupGrace_IsUnhealthy()
     {
         var config = Config(
             ("ControlPlane:ConsistencyMode", "GatedCommit"),
@@ -125,7 +125,7 @@ public class HeartbeatFreshnessHealthCheckTests
 
         var result = await Check(sut);
 
-        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
         Assert.Contains("dc-east", result.Description);
     }
 
@@ -142,9 +142,9 @@ public class HeartbeatFreshnessHealthCheckTests
         clock.Advance(TimeSpan.FromSeconds(HeartbeatFreshnessHealthCheck.DefaultStalenessThresholdSeconds - 1));
         Assert.Equal(HealthStatus.Healthy, (await Check(CreateSut(config, status, clock))).Status);
 
-        // Past the default -> degraded.
+        // Past the default -> unhealthy (hard readiness fence).
         clock.Advance(TimeSpan.FromSeconds(2));
-        Assert.Equal(HealthStatus.Degraded, (await Check(CreateSut(config, status, clock))).Status);
+        Assert.Equal(HealthStatus.Unhealthy, (await Check(CreateSut(config, status, clock))).Status);
     }
 
     [Fact]
@@ -167,33 +167,33 @@ public class HeartbeatFreshnessHealthCheckTests
     }
 
     /// <summary>
-    /// Readiness contract: ASP.NET Core's default health-result mapping treats
-    /// <see cref="HealthStatus.Degraded"/> as HTTP 200 (ready); only
-    /// <see cref="HealthStatus.Unhealthy"/> returns 503. The eval-server readiness endpoint does not
-    /// override that mapping (see <c>MiddlewaresRegister</c>), so a degraded heartbeat keeps
-    /// <c>/health/readiness</c> passing. This check must therefore NEVER return Unhealthy — it only
-    /// ever returns Healthy or Degraded — so it can never fail readiness.
+    /// Readiness contract (HARD FENCE): ASP.NET Core's default mapping returns HTTP 503 for
+    /// <see cref="HealthStatus.Unhealthy"/> (only Healthy/Degraded → 200). The check is tagged for
+    /// <c>/health/readiness</c>, so under GatedCommit a stale heartbeat FAILS readiness and the pod is
+    /// pulled from rotation. Under BestEffort the check is a no-op (never Unhealthy), so it can never
+    /// fence a pod when gating is off.
     /// </summary>
     [Fact]
-    public async Task NeverReturnsUnhealthy_AcrossModesAndAges()
+    public async Task BestEffort_NeverUnhealthy_EvenWhenVeryStale()
     {
-        // BestEffort with a very stale heartbeat.
         var bestEffort = Config(("ControlPlane:ConsistencyMode", "BestEffort"));
         var s1 = new HeartbeatPublishStatus();
         s1.MarkSuccess(T0);
-        Assert.NotEqual(
-            HealthStatus.Unhealthy,
-            (await Check(CreateSut(bestEffort, s1, new FakeClock(T0.AddHours(1))))).Status);
+        // Even an hour stale, BestEffort must stay Healthy (never fences readiness).
+        var result = await Check(CreateSut(bestEffort, s1, new FakeClock(T0.AddHours(1))));
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
 
-        // GatedCommit, far past the threshold and never published — the worst case.
+    [Fact]
+    public async Task GatedCommit_FarPastThreshold_IsUnhealthy_FailingReadiness()
+    {
         var gated = Config(
             ("ControlPlane:ConsistencyMode", "GatedCommit"),
             ("ControlPlane:HeartbeatStalenessThresholdSeconds", "30"));
         var clock = new FakeClock(T0);
-        var sut = CreateSut(gated, new HeartbeatPublishStatus(), clock);
+        var sut = CreateSut(gated, new HeartbeatPublishStatus(), clock); // never published
         clock.Advance(TimeSpan.FromHours(1));
         var result = await Check(sut);
-        Assert.Equal(HealthStatus.Degraded, result.Status);
-        Assert.NotEqual(HealthStatus.Unhealthy, result.Status);
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
     }
 }

--- a/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatServiceTests.cs
+++ b/modules/evaluation-server/tests/Application.IntegrationTests/Health/HeartbeatServiceTests.cs
@@ -37,7 +37,8 @@ public class HeartbeatServiceTests
             new NoopMessageProducer(),
             NullLogger<HeartbeatService>.Instance,
             configuration,
-            reader);
+            reader,
+            new HeartbeatPublishStatus());
 
     [Fact]
     public async Task BuildHeartbeat_PopulatesDcIdAndRegion_FromConfig()


### PR DESCRIPTION
Closes #22. **Mode-dependent HARD readiness fence** (per review — switched from the degraded-signal default).

Under **GatedCommit**, `HeartbeatFreshnessHealthCheck` returns **Unhealthy** when the eval server hasn't published a heartbeat for longer than `ControlPlane:HeartbeatStalenessThresholdSeconds` (default **180s** = 3× heartbeat interval, with a startup grace) — i.e. likely evicted/partitioned. **BestEffort → always Healthy (no-op).**

- Tagged for `/health/readiness` (verified vs `MiddlewaresRegister` predicate + `ReadinessTag`), so **Unhealthy fails readiness (503) and the pod is pulled from LB rotation.** Readiness-only (not liveness) → removed from rotation, not restarted; returns when heartbeats resume.
- **Consistency-over-availability:** a partitioned/evicted DC's eval servers **stop serving entirely** during the partition rather than serving stale-but-consistent values — the explicit strict choice.
- `IHeartbeatPublishStatus` tracks last successful publish; metric `evaluation_server.consistency.heartbeat_staleness_seconds` + one-shot transition warning.

**Verification (unit, no infra):** 16/16 (BestEffort always-Healthy even hours-stale; GatedCommit stale/never-published → Unhealthy; startup-grace Healthy; threshold boundary); build clean; readiness tag wiring confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)